### PR TITLE
Reimplement checkmarks and x's for cosigners. Fixes #29

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -652,28 +652,34 @@ reconsider:
   - final_form
 question: |
   % if all_signatures_in:
-  Your Eviction Moratorium has been signed.
+  Your Eviction Moratorium is ready
   % else:
-  Your Eviction Moratorium has not been signed by everyone yet.
+  Some people still need to sign your Eviction Moratorium
   % endif
 subquestion: |
-  % if not all_signatures_in:
-    % for codef in codefendants:
-      % if defined( codef.attr_name( 'signature' )):
-  ${ codef } has signed.
 
-      % else:
-  ${ codef } has not signed yet.
-
-      % endif
-    % endfor
-  % else:
+  % if all_signatures_in:
     % if len( codefendants ) > 1:
     ${ comma_and_list( codefendants )} have signed.
     % else:
       ${ codefendants[0] } has signed.
     % endif
+  
+  % else:
+    % for signer in codefendants:
+    % if defined( signer.attr_name( 'signature' )):
+    <i class="fa fa-check" aria-hidden="true"></i> ${ signer } has signed[BR]
+    % endif
+    % endfor
+
+    % for signer in codefendants:
+    % if not defined( signer.attr_name( 'signature' )):
+    <i class="fa fa-times" aria-hidden="true"></i> ${ signer } has not signed[BR]
+    % endif
+    % endfor
+  
   % endif
   
   ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='lg') }
+  
 attachment code: motion_to_dismiss_for_non_essential_eviction

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -652,7 +652,7 @@ reconsider:
   - final_form
 question: |
   % if all_signatures_in:
-  Your Eviction Moratorium is ready
+  Your Eviction Moratorium is ready to print
   % else:
   Some people still need to sign your Eviction Moratorium
   % endif


### PR DESCRIPTION
Test:
1. 2 cosigners
1. User signs for cosigner 1 
1. User sends to cosigner 2 somehow
1. User gets to document
1. Cosigner 1 has checkmark next to their name
1. Cosigner 2 has 'x' next to their name
1. Doc is missing cosigner 2's signature
1. Cosigner 2 signs somehow
1. User refreshes document page
1. Everyone is listed as having signed the document.
1. All signatures are in the doc.