### PR TITLE
Update or switch some screens to newest basic questions versions. Fixes #12

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/multipleusers.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/multipleusers.yml
@@ -278,14 +278,6 @@ subquestion: |
   If you are willing to sign, tap to continue.  On the next screen, you will provide your signature.
 continue button field: codefendants[i].willing_to_sign
 ---
-id: Codefendant signature
-generic object: Person
-question: |
-  Sign your name
-signature: x.signature
-under: |
-  ${ x }
----
 id: thank codefendants
 event: codefendants[i].thanked
 reconsider:

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -38,7 +38,7 @@ code: |
   interview_presets
   
   # Skipping for speeding up tests
-  #download_only_intro_screen = True
+  #no_court_email_massaccess_terms = True
   #mtd_intro = True
   #eviction_choice = "no"
   #other_parties.target_number = '1'
@@ -63,7 +63,8 @@ code: |
   #exist_other_local_signers = False
   
   # Real code
-  download_only_intro_screen
+  interview_short_title = 'Ask the court for an Eviction Moratorium'  # Will be easier to switch to basic questions in future
+  no_court_email_massaccess_terms
   mtd_intro
   if eviction_choice == "yes":
     kick_out
@@ -182,26 +183,41 @@ comment: |
   fields:
     - Name: witnesses[i].name.text
 ---
-id: basic questions intro screen
-question: |
-  Mass Access Project
-subquestion: |
-  This interview can help you complete and download court forms in 3 steps:
-  
-  Step 1. Answer questions to fill your motion.  
-  Step 2. Review the completed motion.  
-  Step 3. Download the motion and file it.
-  
+template: additional_terms_of_agreement_instructions
+content: |
   This interview **does not** deliver the motion for you. You must do
   that on your own.
+---
+# MassAccess terms of agreement page for forms that can't be emailed to the court.
+id: terms with no email
+continue button field: no_court_email_massaccess_terms
+question: |
+  ${interview_short_title}: Mass Access Project
+subquestion: |
+ 
+  The MassAccess Project can help you complete and file court forms in 3 steps:
   
+  Step 1. Answer questions that will fill in your form for you.  
+  Step 2. Preview the completed form.  
+  Step 3. Download the motion and file it.
+  
+  ${ additional_terms_of_agreement_instructions }
+
+  Tap the {green words} in any screen for a definition or more information.
+  
+  If you have questions about this form or the court process, 
+  call the Trial Court’s Emergency HelpLine:  
+  833-91-COURT (833-912-6878)  
+  Monday-Friday  
+  8:30am - 4:30pm
+
   % if chat_partners_available().help:
   Live help is currently available in this interview. Click the speech bubble
   (:comment-alt:) in the navigation bar to connect to a live advocate for help.
   % endif
 
 fields:
-  - To continue, read the [terms of use](https://massaccess.suffolklitlab.org/privacy/): acknowledged_information_use
+  - To continue, you must accept the [terms of use](https://massaccess.suffolklitlab.org/privacy/): acknowledged_information_use
     datatype: checkboxes
     none of the above: False    
     minlength: 1
@@ -209,8 +225,17 @@ fields:
       - I accept the terms of use.
     validation messages:
       minlength: |
-        You cannot continue unless you agree to the terms of use.        
-continue button field: download_only_intro_screen
+        You cannot continue unless you agree to the terms of use.
+terms:
+  green words: |
+    Green words are legal terms or a short way of referring to something that needs more explanation. The definition or explanation pops up when you tap the green words.
+right: |
+  % if user_has_saved_answers:
+  ${fa_icon("bell", color="primary", size="sm")}
+  Saved answers available!  
+  
+  ${action_button_html(url_action('load_answer'), icon="folder-open", label=word("View answers"), size="sm" )}
+  % endif    
 ---
 id: number of landlords
 question:  |
@@ -251,10 +276,10 @@ fields:
 ---
 id: contact information
 question: |
-  Contact information
+  What is your contact information?
 subquestion: |
   The court needs to be able to reach you about your case. Give them as many ways as you can.
-fields:
+fields:  
   - Mobile number: users[0].mobile_number
     required: False
   - Other phone number: users[0].phone_number
@@ -262,12 +287,13 @@ fields:
   - Email address: users[0].email    
     datatype: email
     required: False
-  - What is the best way for the court to reach you: users[0].other_contact_method
+  - Other ways to reach you: users[0].other_contact_method
     input type: area
+    required: False
     help: |
       If you do not have a phone number or email the court can use, provide
       specific contact instructions. For example, use a friend's phone number.
-      But the friend must be someone you can trust to tell you the court is
+      But the friend must be someone you can rely on to tell you the court is
       trying to reach you.
 validation code: |
   if (not showifdef('users[0].phone_number') and \
@@ -276,7 +302,10 @@ validation code: |
       (not showifdef('users[0].other_contact_method'))):
     validation_error(word("You need to provide at least one contact method."))
 help: |
-  You _must_ provide contact information so the court can reach you.
+  The court **must** be able to reach you. You have to give them some way to do this.
+  
+  Some forms let you tell the court you need to keep your address, phone,
+  and email confidential, so that only court staff can see this information. 
 ---
 id: eviction mtd covid intro screen
 question: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -1,5 +1,4 @@
 ---
-# TODO: Use more basic questions?
 # TODO: Explore new `session_local`, etc. features
 ---
 mandatory: True
@@ -64,18 +63,18 @@ code: |
   #exist_other_local_signers = False
   
   # Real code
-  interview_short_title = 'Ask the court for an Eviction Moratorium'  # Will be easier to switch to basic questions in future
-  no_court_email_massaccess_terms
+  interview_short_title = 'Ask the court for an Eviction Moratorium'  # Will be easier to switch to basic questions in future. Can be moved into its own block.
+  no_court_email_massaccess_terms  # Custom
   mtd_intro
   if eviction_choice == "yes":
     kick_out
   users[0].name.first
   users[0].address.address
   users[0].mobile_number
-  other_parties.target_number
-  other_parties.gather()
   users.gathered = True
   users.there_is_another = False
+  other_parties.target_number
+  other_parties.gather()
   codefendants.gather()
   courts[0]
   docket_numbers[0]

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -7,9 +7,10 @@ code: |
   multi_user = True
 ---
 include:
-  - docassemble.MAVirtualCourt:basic-questions.yml
   - sign_on_device.yml
   - parent_interview_redis_handler.yml
+  # The questions below here should supercede the above files
+  - docassemble.MAVirtualCourt:basic-questions.yml
 ---
 modules:
   - docassemble.base.util
@@ -606,26 +607,26 @@ content: |
 ---
 id: send user email
 code: |
-  users[0].message_succeeded = send_email(to=users[0], template=initial_email_template)
+  if remote_signers.number() > 0:
+    users[0].message_succeeded = send_email(to=users[0], template=initial_email_template)
   users[0].was_notified_of_cosigner_messages = True
 ---
-id: user email before signatures
+id: after remote signatures requested
 template: initial_email_template
 subject: |
-  Your Motion to Dismiss was sent to ${ codefendants[i] }
+  Your Motion to Dismiss was sent to ${ comma_and_list( remote_signers ) }
 content: |
-
   ${ users[0] },
 
-  % if codefendants.number() == 1:
-  We e-mailed ${ codefendants[i] } to ask for their signature on the Motion to Dismiss.
+  % if remote_signers.number() == 1:
+  We e-mailed ${ remote_signers } to ask for their signature on the Motion to Dismiss.
 
-  We will e-mail you when ${ codefendants[i] } has signed.  But, you can [check if ${ codefendants[i] } signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
+  We will e-mail you when ${ remote_signers } has signed, but you can also [check if ${ remote_signers } signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
   
   % else:
-  We e-mailed ${ codefendants[i] } to ask them to sign your Motion to Dismiss.
+  We e-mailed ${ comma_and_list( remote_signers ) } to ask them to sign your Motion to Dismiss.
 
-  We will e-mail you when everyone has signed.  But, you can [check if ${ codefendants[i] } have signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
+  We will e-mail you when everyone has signed, but you can also [check if ${ comma_and_list( remote_signers ) } have signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
   % endif
 ---
 # Must come from an `action`. Needed for security.
@@ -700,14 +701,6 @@ code: |
 #################
 # Interview-specific UI
 #################
-id: signature
-generic object: Individual
-question: |
-  Sign your name, ${ x }
-signature: x.signature
-under: |
-  ${ x }
----
 id: if all signed send email
 # Is requested when people check on the status of the signatures
 code: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -63,7 +63,7 @@ code: |
   #exist_other_local_signers = False
   
   # Real code
-  interview_short_title = 'Ask the court for an Eviction Moratorium'  # Will be easier to switch to basic questions in future. Can be moved into its own block.
+  interview_short_title = 'Ask the court for a Motion to Dismiss a Non-Essential Eviction'  # Will be easier to switch to basic questions in future. Can be moved into its own block.
   no_court_email_massaccess_terms  # Custom
   mtd_intro
   if eviction_choice == "yes":


### PR DESCRIPTION
- [x] Take care of #51 before this one.

[Fixes #12]

For a couple screens, I just copied the newest versions of the basic questions and put them in our file, changing what we need to be different. These were those screens:

1. Accept terms of use screen
1. Contact info screen

You were right that only one screen got switched out for a purely basic-questions screen: The signature screen. I had to adjust the order of the `include`d files to get the correct behavior.