### PR TITLE
Ask for codefendant court contact info. Fixes #63. For #64, #59, #31.

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -371,18 +371,32 @@ fields:
       - Email: email
       - Text: text
   - What email should we use to ask for their signature?: codefendants[i].signature_email
+    default: ${ codefendants[i].email }
     js show if: |
       val("codefendants[i].send_method") == "email"
   - What number should we text to ask for their signature?: codefendants[i].signature_number
+    default: ${ codefendants[i].mobile_number }
     js show if: |
       val("codefendants[i].send_method") == "text"
+---
+id: cosigner contact info
+question: |
+  How should the court contact ${ codefendants[i] }?
+subquestion: |
+  Make sure you have ${ codefendants[i].familiar() }'s permission to put this on the form.
+fields:
+  - Mobile number: codefendants[i].mobile_number
+    required: False
+  - Other phone number: codefendants[i].phone_number
+    required: False
+  - Email address: codefendants[i].email    
+    datatype: email
+    required: False
 ---
 id: get codefendant info
 code: |
   codefendants[i].name.first
-  #codefendants[i].send_method
-  #codefendants[i].signature
-  #codefendants[i].signature_date
+  codefendants[i].mobile_number
   codefendants[i].complete = True
 ---
 id: placeholder


### PR DESCRIPTION
Fixes #63. Addresses #64, #59, #31

Test:

(User has 2 codefendants)
1. User gives all court contact info for codefendant 1
1. User gives 0 court contact info for codefendant 2
1. User does not sign for codefs. Neither codef signs on user device.
1. User gets to preview.
1. Preview has correct court contact info for codefendants (second page of form)
1. At input fields to send signature links to codef:
   1. Codef 1 should have default values for email and text equal to the info they put in
   1. Codef 2 should have blank fields

The end.