### PR TITLE
Render a blank line as docx service when service unknown. Fixes #46, fixes #25.

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -91,8 +91,11 @@ code: |
 
   ready_to_serve
   if ready_to_serve:
-    if service_method != "not_know":
+    if service_method == '______________________________________________':
+      service_date = '_______________________'
+    else:
       service_date
+      
 
   preview_screen  # Must define form_to_sign=
 
@@ -475,7 +478,7 @@ fields:
       - By email: electronic mail
       - By mail (with postage paid by me): first class mail, postage prepaid
       - other: _________________________
-      - I do not know: _______________________
+      - I do not know: ______________________________________________
     show if:
       ready_to_serve
   - Other method: service_method


### PR DESCRIPTION
Fixes #46, allow user to fill in service when they know what it is.
Fixes #25 too I think. Sorry, I think I duplicated the issue.

Test 1:
1. Select service unknown
1. Observe that date of service isn't asked
1. In preview, see blank line for service method and blank line for service date.

(hit back)

Test 2:
1. Select service by mail
1. Give date of service
1. In preview, see service by mail described