### PR TITLE
Make initial email dynamic to number of codefendants. Fixes #109.

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -640,12 +640,12 @@ content: |
   ${ users[0] },
   
   % if len( remote_signers ) == 1:
-  We sent a message to ${ comma_and_list( remote_signers ) } to ask for their signature on the Motion to Dismiss. We will e-mail you when ${ remote_signers } has signed.
+  We asked ${ comma_and_list( remote_signers ) } to sign your Motion to Dismiss. We will e-mail you when ${ remote_signers } signs it.
 
   You can also [tap here to check if ${ comma_and_list( remote_signers ) } has signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
 
   % else:
-  We sent a message to ${ comma_and_list( remote_signers ) } to ask for their signatures on the Motion to Dismiss. We will e-mail you when they have signed.
+  We asked ${ comma_and_list( remote_signers ) } to sign your Motion to Dismiss. We will e-mail you when they sign it.
   
   You can also [tap here to check if ${ comma_and_list( remote_signers ) } have signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
   % endif

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -639,12 +639,15 @@ subject: |
 content: |
   ${ users[0] },
   
-  We sent a message to ${ comma_and_list( remote_signers ) }  to ask for their signature on the Motion to Dismiss. We will e-mail you when they have signed.
-
   % if len( remote_signers ) == 1:
-  You can also [check if ${ comma_and_list( remote_signers ) } has signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
+  We sent a message to ${ comma_and_list( remote_signers ) } to ask for their signature on the Motion to Dismiss. We will e-mail you when ${ remote_signers } has signed.
+
+  You can also [tap here to check if ${ comma_and_list( remote_signers ) } has signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
+
   % else:
-  You can also [check if ${ comma_and_list( remote_signers ) } have signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
+  We sent a message to ${ comma_and_list( remote_signers ) } to ask for their signatures on the Motion to Dismiss. We will e-mail you when they have signed.
+  
+  You can also [tap here to check if ${ comma_and_list( remote_signers ) } have signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
   % endif
 ---
 # TODO: Check if user email is going to be required in this flow

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -638,14 +638,14 @@ subject: |
   Your Motion to Dismiss was sent to ${ comma_and_list( remote_signers ) }
 content: |
   ${ users[0] },
-
-  % if remote_signers.number() == 1:
-  We e-mailed ${ remote_signers } to ask for their signature on the Motion to Dismiss. We will e-mail you when they have signed.
-  % else:
-  We e-mailed ${ comma_and_list( remote_signers ) } to ask them to sign your Motion to Dismiss. We will e-mail you when everyone has signed.
-  % endif
   
+  We sent a message to ${ comma_and_list( remote_signers ) }  to ask for their signature on the Motion to Dismiss. We will e-mail you when they have signed.
+
+  % if len( remote_signers ) == 1:
+  You can also [check if ${ comma_and_list( remote_signers ) } has signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
+  % else:
   You can also [check if ${ comma_and_list( remote_signers ) } have signed the motion](${ interview_url_action('check_status', party_id=users[0].id) }).
+  % endif
 ---
 # TODO: Check if user email is going to be required in this flow
 code: |


### PR DESCRIPTION
Fixes #109 - initial email to user notifying them that the links to their codefendants has wrong grammar for a single codefendant.

Test 1:
(one codefendant)
1. User texts or emails the codefendant
1. User signs the document
1. User sees initial email - language should be correct for one codefendant

Test 2:
(two codefendants)
1. User texts or emails the codefendants
1. User signs the document
1. User sees initial email - language should be correct for two codefendants
