### PR TITLE
Add QR code to when phone is chosen (finally). Close #118.

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -695,25 +695,23 @@ code: |
 # Interfacing with code to let user choose which device to sign on
 ######################
 ---
-id: number to text for signature
-generic object: Individual
-question: |
-  Sign on a phone
-subquestion: |
-  What number do you want to test this to for a signature?
-fields:
-  - no label: x.device_number
-    default: ${ showifdef( x.attr_name( 'mobile_number' )) }
+#id: number to text for signature
+#generic object: Individual
+#question: |
+#  Sign on a phone
+#subquestion: |
+#  What number do you want to text this to for a signature?
+#fields:
+#  - no label: x.device_number
+#    default: ${ showifdef( x.attr_name( 'mobile_number' )) }
 ---
 generic object: Individual
 code: |
   # TODO: Should this be in sign_on_device.yml?
   # TODO: Send with action arguments (in templates)
-  #if x.send_method == 'text':
-  #  x.send_sms_signature_link
-  #elif x.send_method == 'email':  # Not implemented for MVP
-  #  x.send_email_signature_link
-  x.message_result = send_sms(task='send link to other device', to=x.device_number, template=x.sms_device_template)
+  # No email for MVP?
+  if defined( x.attr_name( 'device_number' )):
+    x.message_result = send_sms(task='send link to other device', to=x.device_number, template=x.sms_device_template)
   x.send_signature_link = True  # Used by sign_on_device.yml
 ---
 generic object: Individual
@@ -728,6 +726,7 @@ code: |
   # `action` experiments for true device choice begin here
   long_device_choice_url = interview_url_action( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
   device_choice_url = shortenMe( long_device_choice_url ).shortenedURL
+  qr_url = interview_url_action_as_qr( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
 ---
 code: |
   signature_data_id = get_random_chars()

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -82,6 +82,7 @@ code: |
 code: |
   long_device_choice_url = interview_url_action( 'get_remote_signature', device_id='tbd', signature_data_id=signature_data_id, party_id=signer.id )
   device_choice_url = shortenMe( long_device_choice_url ).shortenedURL
+  qr_url = interview_url_action_as_qr( 'get_remote_signature', device_id='tbd', signature_data_id=signature_data_id, party_id=signer.id )
 ---
 ###################
 # Interfacing directly with remote signer interview order code
@@ -118,11 +119,9 @@ generic object: Individual
 code: |
   # TODO: Should this be in sign_on_device.yml?
   # TODO: Send with action arguments (in templates)
-  #if x.send_method == 'text':
-  #  x.send_sms_signature_link
-  #elif x.send_method == 'email':  # Not implemented for MVP
-  #  x.send_email_signature_link
-  x.message_result = send_sms(task='send link to other device', to=x.device_number, template=x.sms_device_template)
+  # No email for MVP?
+  if defined( x.attr_name( 'device_number' )):
+    x.message_result = send_sms(task='send link to other device', to=x.device_number, template=x.sms_device_template)
   x.send_signature_link = True  # Used by sign_on_device.yml
 ---
 id: signature

--- a/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
@@ -126,15 +126,36 @@ code: |
 #  x.status
 ---
 id: send_method
+# Do not define `qr_url` as it should need id that can't be made here
 # for now, just get the mobile number
 generic object: Individual
 question: |
-  Send this to your mobile device
+  Sign on a phone or tablet
 subquestion: |
-  You can use a QR code that could be here or you can text your mobile device.
+  % if qr_url:
+  You can text yourself a link or you can use the QR code.
+  % endif
 fields:
   - Number to text: x.device_number
     default: ${ showifdef( x.attr_name( 'mobile_number' )) }
+    required: False
+  - note: |
+      % if qr_url:
+      ---
+      
+      To use this QR code:
+
+      1. Open the camera app or barcode reader app on your phone.
+      1. Point your phone at the QR code to scan it.
+      1. Tap the pop-up notification.
+      
+      <center>
+      ${ qr_url }
+      </center>
+      % endif
+---
+code: |
+  qr_url = False  # Fallback
 ---
 id: x.wants_to_change_device
 generic object: Individual


### PR DESCRIPTION
Closes #118 - This means they don't ever have to give us their phone number if they have the ability to use a QR code. It'll also match the features the current basic questions have.

Test 1:
_You need QR code reader to do this test. (I don't have one)_

- [x] User has 1 codef
- [x] User will send link to codef (as long as you can get the link on your computer, this can be text or email)
- [x] User gets to choosing a device to sign on
- [x] User chooses a phone
- [x] User sees QR code and uses QR code (phone number is not required)
- [x] User signs
- [x] Codef gets link on computer
- [x] Codef goes to interview to the point where they choose a device to sign on
- [x] Codef chooses a phone
- [x] Codef sees QR code and uses QR code (phone number is not required)
- [x] Codef signs
- [x] All is well
