### PR TITLE
Tell unwilling they can redo, add 'start again' button. Close #116.

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -163,9 +163,15 @@ subquestion: |
 id: unwilling to sign end
 generic object: Individual
 event: x.unwilling_to_sign_end
+# TODO: Discuss if 'you can come back later' is more or less clear
 question: |
-  Thank you and goodbye
+  You did not sign the motion
+subquestion: |
+  If you change your mind later and want to sign it, go back to the message and click the link again.
+  
+  Thank you and goodbye.
 buttons:
+  - Start again: restart
   - Exit: exit
 ---
 id: unauthorized


### PR DESCRIPTION
Closes #116, wording for kickout screen for unwilling cosigners. I added 'later' as described in the comment in the issue.

Test 1:
- [x] User has 1 cosigner they send the link to
- [x] User gets to the download document/status page
- [x] Cosigner says they're not wiling to sign
- [x] Cosigner sees appropriate text (plus I added the word 'later')