### PR TITLE
Notify user of cosigner actions. #111 and #112 partial features

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/parent_interview_redis_handler.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/parent_interview_redis_handler.yml
@@ -50,7 +50,7 @@ event: update_stored_data
 # Not quite sure what all to reconsider in this place, honestly
 code: |
   signature_data = redis.get_data( signature_data_id )
-  # recinsider( 'update_custom_redis_data' )  # Maybe
+  # reconsider( 'update_custom_redis_data' )  # Maybe
   # redis.set_data( signature_data_id, signature_data, expire=remote_siganure_expiration_ms )
 ---
 # Updates remote user data for doc and other things

--- a/docassemble/MAEvictionMoratorium/data/questions/parent_interview_redis_handler.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/parent_interview_redis_handler.yml
@@ -19,6 +19,7 @@ mandatory: True
 code: |
   multi_user = True
 ---
+# TODO: Consider changing model. First create the standard data in here, then send it to be modified/customized by the originating interview, then store it. Might be a model more suited to an advanced user, though.
 code: |
   signature_data_id
 
@@ -30,6 +31,7 @@ code: |
   # DEVELOPERS: Create `signature_data` elsewhere, as shown below
   signature_data = {}
   if defined('custom_signature_redis_data'):
+    # Maybe reconsider('custom_signature_redis_data')
     signature_data = custom_signature_redis_data
   
   parties = {}
@@ -42,7 +44,16 @@ code: |
   redis.set_data( signature_data_id, signature_data, expire=remote_siganure_expiration_ms )
   set_initial_redis_data = True
 ---
-# Updates user doc with remote signatures
+event: update_stored_data
+# Current use expectation - update final form
+# Possible way to deal with edited answers
+# Not quite sure what all to reconsider in this place, honestly
+code: |
+  signature_data = redis.get_data( signature_data_id )
+  # recinsider( 'update_custom_redis_data' )  # Maybe
+  # redis.set_data( signature_data_id, signature_data, expire=remote_siganure_expiration_ms )
+---
+# Updates remote user data for doc and other things
 code: |
   new_data = redis.get_data( signature_data_id )
   signing_parties = new_data[ 'parties' ]

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -569,6 +569,8 @@ attachment:
   docx template file: motion_to_dismiss_for_non-essential_eviction.docx
   variable name: preview_doc
 ---
+reconsider:
+  - motion_to_dismiss_for_non_essential_eviction
 code: |
   final_form = pdf_concatenate(motion_to_dismiss_for_non_essential_eviction, filename="dismiss-non-essential-eviction.pdf")
   final_form.set_attributes(private=False, persistent=True)
@@ -669,7 +671,7 @@ code: |
 event: send_final_email
 code: |
   if defined( 'users[0].email' ) and users[0].email:
-    final_email_result = send_email(to=users[0], template=final_email_template, attachments=motion_to_dismiss_for_non_essential_eviction)
+    final_email_result = send_email(to=users[0], template=final_email_template, attachments=final_form)
   background_response()
 ---
 id: all signed email template
@@ -782,7 +784,6 @@ reconsider:
   - collect_signer_types
   - get_stored_data
   - all_signatures_in
-  - motion_to_dismiss_for_non_essential_eviction
   - final_form
 question: |
   % if all_signatures_in:
@@ -834,4 +835,4 @@ subquestion: |
   
   ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='lg') }
   
-attachment code: motion_to_dismiss_for_non_essential_eviction
+attachment code: final_form

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -597,12 +597,22 @@ code: |
 ---
 reconsider:
   - form_to_sign
+  - final_form
 code: |
   # Whatever info you want to be able to use for the co-signers' interview
   custom_signature_redis_data = {
-    'user_names': str(users),
+    'user_names': comma_and_list(users),
     'preview': form_to_sign,
+    'final_form': final_form,  # only works because it's docx
+    'user_email': users[0].email if defined('users[0].email') else None,
+    'user_mobile': users[0].mobile_number if defined('users[0].mobile_number') else None,
+    'interview_url': shortenMe( interview_url_action('check_status', party_id=users[0].id) ).shortenedURL
   }
+---
+# Possible way to deal with edited answers
+event: update_custom_redis_data
+code: |
+  reconsider( 'custom_signature_redis_data' )
 ---
 id: sms template multiuser
 template: codefendants[i].sms_template

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -671,7 +671,7 @@ code: |
 event: send_final_email
 code: |
   if defined( 'users[0].email' ) and users[0].email:
-    final_email_result = send_email(to=users[0], template=final_email_template, attachments=final_form)
+    final_email_result = send_email(to=users[0], template=final_email_template, attachments=motion_to_dismiss_for_non_essential_eviction)
   background_response()
 ---
 id: all signed email template
@@ -784,6 +784,7 @@ reconsider:
   - collect_signer_types
   - get_stored_data
   - all_signatures_in
+  - motion_to_dismiss_for_non_essential_eviction
   - final_form
 question: |
   % if all_signatures_in:
@@ -835,4 +836,4 @@ subquestion: |
   
   ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='lg') }
   
-attachment code: final_form
+attachment code: motion_to_dismiss_for_non_essential_eviction

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -155,7 +155,7 @@ content: |
   
   We sent ${ signer } a link to your Motion to Dismiss a Non-Essential Eviction. They said they would not sign the motion. Call or talk to ${ signer } to find out if the contact information you wrote is correct. If it is wrong, fill out a new form with the correct information.
 
-  If ${ signer } does not want to sign, you can fill out a new form. Do not add them as signing codefendant on the document.
+  If ${ signer } does not want to sign the motion, you can still print or download it without ${ signer }'s signature and file it with the court.
 
   [Tap here to go back to the form and check your document's status](${ redis.get_data( signature_data_id )['interview_url'] }).
 ---

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -68,6 +68,7 @@ generic object: Individual
 code: |
   x.signature_date = today()
   x.has_signed = True
+  x.signature.set_attributes(private=False, persistent=True)
   store_signature_data( x )
 
   x.after_signature_saved

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -25,8 +25,8 @@ mandatory: True
 code: |
   multi_user = True
 ---
----
 # Currently getting here with the url in the console of the initial interview
+# This can be customized as well if you want to do different stuff before running the rest
 mandatory: True
 code: |
   get_remote_signature
@@ -85,6 +85,7 @@ code: |
 ---
 ###################
 # Interfacing directly with remote signer interview order code
+# Uses custom stored data from the user's interview
 ##################
 ---
 id: willing to sign
@@ -101,14 +102,72 @@ id: x.after_signature_saved
 event: x.after_signature_saved
 generic object: Individual
 code: |
+  # Maybe there's no final notification. They just see
+  # all these notifications.
+  if user_email: send_signature_complete_email
+  if user_mobile: send_signature_complete_sms
   x.end
   #x.status
+---
+code: |
+  send_email(to=(redis.get_data( signature_data_id )['user_email']), template=signed_email_template)
+  send_signature_complete_email = True
+---
+code: |
+  send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=signed_sms_template)
+  send_signature_complete_sms = True
+---
+template: signed_email_template
+subject: |
+  ${ signer } has signed your Motion to Dismiss
+content: |
+  ${ redis.get_data( signature_data_id )['user_names'] },
+
+  ${ signer } has signed your Motion to Dismiss a Non-Essential Eviction. [Tap here to check your document's status](${ redis.get_data( signature_data_id )['interview_url'] }).
+---
+template: signed_sms_template
+content: |
+  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } has signed your Motion to Dismiss a Non-Essential Eviction. Use the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }.
 ---
 id: x.after_unwilling_to_sign_saved
 event: x.after_unwilling_to_sign_saved
 generic object: Individual
 code: |
+  if user_email: send_unwilling_email
+  if user_mobile: send_unwilling_sms
   x.unwilling_to_sign_end
+---
+code: |
+  send_email(to=(redis.get_data( signature_data_id )['user_email']), template=unwilling_email_template)
+  send_unwilling_email = True
+---
+code: |
+  send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=unwilling_sms_template)
+  send_unwilling_sms = True
+---
+template: unwilling_email_template
+# at ${ signer.signature_email if defined('signer.signature_email') else signer.signature_number } (something complex to show both)
+# TODO: When feature is ready, add that they can edit/resend to cosigner
+subject: |
+  ${ signer } will not sign you Motion to Dismiss
+content: |
+  ${ redis.get_data( signature_data_id )['user_names'] },
+  
+  We sent ${ signer } a link to your Motion to Dismiss a Non-Essential Eviction. They said they would not sign the motion. Call or talk to ${ signer } to find out if the contact information you wrote is correct. If it is wrong, fill out a new form with the correct information.
+
+  If ${ signer } does not want to sign, you can fill out a new form. Do not add them as signing codefendant on the document.
+
+  [Tap here to go back to the form and check your document's status](${ redis.get_data( signature_data_id )['interview_url'] }).
+---
+template: unwilling_sms_template
+content: |
+  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } will not sign your Motion to Dismiss a Non-Essential Eviction. Tap the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }.
+---
+code: |
+  user_email = redis.get_data( signature_data_id )['user_email']
+---
+code: |
+  user_mobile = redis.get_data( signature_data_id )['user_mobile']
 ---
 ###################
 # Interfacing directly with script for user choosing other device to sign on

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -104,18 +104,16 @@ generic object: Individual
 code: |
   # Maybe there's no final notification. They just see
   # all these notifications.
-  if user_email: send_signature_complete_email
-  if user_mobile: send_signature_complete_sms
+  send_signature_complete_user_notifications
   x.end
   #x.status
 ---
 code: |
-  send_email(to=(redis.get_data( signature_data_id )['user_email']), template=signed_email_template)
-  send_signature_complete_email = True
----
-code: |
-  send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=signed_sms_template)
-  send_signature_complete_sms = True
+  if redis.get_data( signature_data_id )['user_email']: 
+    send_email(to=(redis.get_data( signature_data_id )['user_email']), template=signed_email_template)
+  if redis.get_data( signature_data_id )['user_mobile']:
+    send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=signed_sms_template)
+  send_signature_complete_user_notifications = True
 ---
 template: signed_email_template
 subject: |
@@ -127,23 +125,21 @@ content: |
 ---
 template: signed_sms_template
 content: |
-  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } has signed your Motion to Dismiss a Non-Essential Eviction. Use the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }.
+  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } has signed your Motion to Dismiss a Non-Essential Eviction. Use the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }
 ---
 id: x.after_unwilling_to_sign_saved
 event: x.after_unwilling_to_sign_saved
 generic object: Individual
 code: |
-  if user_email: send_unwilling_email
-  if user_mobile: send_unwilling_sms
+  send_unwilling_user_notifications
   x.unwilling_to_sign_end
 ---
 code: |
-  send_email(to=(redis.get_data( signature_data_id )['user_email']), template=unwilling_email_template)
-  send_unwilling_email = True
----
-code: |
-  send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=unwilling_sms_template)
-  send_unwilling_sms = True
+  if redis.get_data( signature_data_id )['user_email']:
+    send_email(to=(redis.get_data( signature_data_id )['user_email']), template=unwilling_email_template)
+  if redis.get_data( signature_data_id )['user_mobile']:
+    send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=unwilling_sms_template)
+  send_unwilling_user_notifications = True
 ---
 template: unwilling_email_template
 # at ${ signer.signature_email if defined('signer.signature_email') else signer.signature_number } (something complex to show both)
@@ -161,7 +157,7 @@ content: |
 ---
 template: unwilling_sms_template
 content: |
-  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } will not sign your Motion to Dismiss a Non-Essential Eviction. Tap the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }.
+  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } will not sign your Motion to Dismiss a Non-Essential Eviction. Tap the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }
 ---
 code: |
   user_email = redis.get_data( signature_data_id )['user_email']

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -174,12 +174,6 @@ template: unwilling_sms_template
 content: |
   ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } will not sign your Motion to Dismiss a Non-Essential Eviction. Tap the link to see your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }
 ---
-code: |
-  user_email = redis.get_data( signature_data_id )['user_email']
----
-code: |
-  user_mobile = redis.get_data( signature_data_id )['user_mobile']
----
 ###################
 # Interfacing directly with script for user choosing other device to sign on
 ##################

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -104,16 +104,23 @@ generic object: Individual
 code: |
   # Maybe there's no final notification. They just see
   # all these notifications.
-  send_signature_complete_user_notifications
+  trigger_signature_complete_user_notifications
   x.end
   #x.status
 ---
 code: |
-  if redis.get_data( signature_data_id )['user_email']: 
-    send_email(to=(redis.get_data( signature_data_id )['user_email']), template=signed_email_template)
-  if redis.get_data( signature_data_id )['user_mobile']:
-    send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=signed_sms_template)
-  send_signature_complete_user_notifications = True
+  background_action('send_signature_complete_user_notifications')
+  trigger_signature_complete_user_notifications = True
+---
+event: send_signature_complete_user_notifications
+code: |
+  if task_not_yet_performed('send_signed_email') and redis.get_data( signature_data_id )['user_email']: 
+    send_email(task='send_signed_email', to=(redis.get_data( signature_data_id )['user_email']), template=signed_email_template)
+    
+  if task_not_yet_performed('send_signed_sms') and redis.get_data( signature_data_id )['user_mobile']:
+    send_sms(task='send_signed_sms', to=(redis.get_data( signature_data_id )['user_mobile']), template=signed_sms_template)
+    
+  background_response()
 ---
 template: signed_email_template
 subject: |
@@ -121,25 +128,32 @@ subject: |
 content: |
   ${ redis.get_data( signature_data_id )['user_names'] },
 
-  ${ signer } has signed your Motion to Dismiss a Non-Essential Eviction. [Tap here to check your document's status](${ redis.get_data( signature_data_id )['interview_url'] }).
+  ${ signer } has signed your Motion to Dismiss a Non-Essential Eviction. [Tap here to go back to the form and see your document](${ redis.get_data( signature_data_id )['interview_url'] }).
 ---
 template: signed_sms_template
 content: |
-  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } has signed your Motion to Dismiss a Non-Essential Eviction. Use the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }
+  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } has signed your Motion to Dismiss. Use the link to see your document. ${ redis.get_data( signature_data_id )['interview_url'] }
 ---
 id: x.after_unwilling_to_sign_saved
 event: x.after_unwilling_to_sign_saved
 generic object: Individual
 code: |
-  send_unwilling_user_notifications
+  trigger_unwilling_user_notifications
   x.unwilling_to_sign_end
 ---
 code: |
-  if redis.get_data( signature_data_id )['user_email']:
-    send_email(to=(redis.get_data( signature_data_id )['user_email']), template=unwilling_email_template)
-  if redis.get_data( signature_data_id )['user_mobile']:
-    send_sms(to=(redis.get_data( signature_data_id )['user_mobile']), template=unwilling_sms_template)
-  send_unwilling_user_notifications = True
+  background_action('send_unwilling_user_notifications')
+  trigger_unwilling_user_notifications = True
+---
+event: send_unwilling_user_notifications
+code: |
+  if task_not_yet_performed('send_unwilling_email') and redis.get_data( signature_data_id )['user_email']:
+    send_email(task='send_unwilling_email', to=(redis.get_data( signature_data_id )['user_email']), template=unwilling_email_template)
+    
+  if task_not_yet_performed('send_unwilling_sms') and redis.get_data( signature_data_id )['user_mobile']:
+    send_sms(task='send_unwilling_sms', to=(redis.get_data( signature_data_id )['user_mobile']), template=unwilling_sms_template)
+    
+  background_response()
 ---
 template: unwilling_email_template
 # at ${ signer.signature_email if defined('signer.signature_email') else signer.signature_number } (something complex to show both)
@@ -153,11 +167,11 @@ content: |
 
   If ${ signer } does not want to sign the motion, you can still print or download it without ${ signer }'s signature and file it with the court.
 
-  [Tap here to go back to the form and check your document's status](${ redis.get_data( signature_data_id )['interview_url'] }).
+  [Tap here to go back to the form and see your document's status](${ redis.get_data( signature_data_id )['interview_url'] }).
 ---
 template: unwilling_sms_template
 content: |
-  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } will not sign your Motion to Dismiss a Non-Essential Eviction. Tap the link to check your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }
+  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } will not sign your Motion to Dismiss a Non-Essential Eviction. Tap the link to see your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }
 ---
 code: |
   user_email = redis.get_data( signature_data_id )['user_email']
@@ -183,7 +197,7 @@ code: |
 id: signature
 generic object: Individual
 question: |
-  Signature ${ x }
+  ${ x }, sign below
 signature: x.signature
 ---
 ###################

--- a/docassemble/MAEvictionMoratorium/signing_party.py
+++ b/docassemble/MAEvictionMoratorium/signing_party.py
@@ -85,11 +85,14 @@ def set_signer_attributes( signer, signature_data_id, party_id ):
   
   if party_data:
     signer.valid = True
-    signer.signature_data_id = signature_data_id
-    signer.id = party_id
     signer.name.first = party_data['name']
     signer.has_signed = party_data['has_signed']
     signer.was_willing = party_data['willing_to_sign']
+    #for key, value in party_data.items():
+    #  #signer.set_attr( key, value, None )
+    #  setattr( signer, key, value )
+    signer.signature_data_id = signature_data_id
+    signer.id = party_id
 
   return signer
   

--- a/docassemble/MAEvictionMoratorium/signing_party.py
+++ b/docassemble/MAEvictionMoratorium/signing_party.py
@@ -142,7 +142,7 @@ def store_signature_data( signer ):
   #signer.signature_date = today()
   #signer.has_signed = True
   # TODO: Set persistance and privacy of signature? Seems to funciton without, or is that in other code somewhere?
-  store_signer_attribute( signer.signature_data_id, signer.id, 'signature', signer.signature.set_attributes(private=False, persistent=True) )
+  store_signer_attribute( signer.signature_data_id, signer.id, 'signature', signer.signature )
   store_signer_attribute( signer.signature_data_id, signer.id, 'signature_date', today() )
   return store_signer_attribute( signer.signature_data_id, signer.id, 'has_signed', True )
   

--- a/docassemble/MAEvictionMoratorium/signing_party.py
+++ b/docassemble/MAEvictionMoratorium/signing_party.py
@@ -142,7 +142,7 @@ def store_signature_data( signer ):
   #signer.signature_date = today()
   #signer.has_signed = True
   # TODO: Set persistance and privacy of signature? Seems to funciton without, or is that in other code somewhere?
-  store_signer_attribute( signer.signature_data_id, signer.id, 'signature', signer.signature )
+  store_signer_attribute( signer.signature_data_id, signer.id, 'signature', signer.signature.set_attributes(private=False, persistent=True) )
   store_signer_attribute( signer.signature_data_id, signer.id, 'signature_date', today() )
   return store_signer_attribute( signer.signature_data_id, signer.id, 'has_signed', True )
   


### PR DESCRIPTION
Sends notifications about cosigner actions to user:
1. Cosigner has signed.
1. Cosigner is unwilling to sign.

Does not yet implement:
1. Telling the user what email or phone number the message was sent to.
1. Telling the user to go to the interview to edit that information.
1. Telling the user to go to the interview to re-send the message.

To discuss:
1. I think editing and resending may be post-MVP features - nice, but the form isn't that long and this can still help people even if they have to re-do the form.
1. Listing the email/phone number in the message is more complicated than listing it on the status page. I think it might be worth taking that off of MVP as well.
1. As far as MVP goes, this may be sufficient to deal with #104. The user will know everyone has signed because they would have gotten notifications for all the signatures. It may actually be less confusing. If that is sufficient, do we want to make an issue to remove the final email notification that gets sent when the user hits 'Check again'?

Test 1:
- [x] User has one codefendant
- [x] User chooses email or text for codefendant
- [x] User gives their phone number and email
- [x] User signs
- [x] Codef goes to link and says they're not willing to sign
- [x] Within 15 min, user gets one text and one email that codef is not willing to sign
- [x] There are links in the messages. Both correctly open the the interview to the status page
- [x] Codef goes to link again and again says they're not willing to sign
- [x] Within 15 min, user gets one new text and one new email that codef is not willing to sign
- [x] There are links in the messages. Both correctly open the the interview to the status page
- [x] Codef goes to link again and signs
- [x] Within 15 min, user gets one new text and one new email that codef has signed
- [x] There are links in the messages. Both correctly open the the interview to the status page
