### PR TITLE
Hide 'Check again' when no codefs. Shrink button. Close #76

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -822,6 +822,8 @@ subquestion: |
   <i class="fa fa-pen-alt" aria-hidden="true"></i> ${ signer } will sign on the document when you print it.
   % endfor
   
-  ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='lg') }
+  % if codefendants.number() > 0:
+  ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='md') }
+  % endif
   
 attachment code: motion_to_dismiss_for_non_essential_eviction


### PR DESCRIPTION
As per #76 - only hide 'Check again' button on final page when there are no codefendants. Additional question was just added to issue about hiding when there are no codefendants who will sign on a separate device.

[Edit: Can be replaced by #136, which only shows 'Check again' if there are any codefs signing on their own devices.]

Test 1:
- [ ] User has 1 codef
- [ ] User will text or email link to codef
- [ ] User gets to final page
- [ ] User sees a 'Check again' button

Test 2:
- [ ] User has 0 codefs
- [ ] User gets to final page
- [ ] User sees no button

# DO NOT TEST THIS HERE

Test 3 is only for #136 if it is chosen instead of this PR

> Test 3:
> - [ ] User has 3 codefs
> - [ ] User will sign for cod 1
> - [ ] Cod 2 will sign on user's device
> - [ ] Cod 3 will sign on paper copy
> - [ ] User gets to final page
> - [ ] User sees no button
