### PR TITLE
Hide 'Check again' when no remote signers. Shrink button. Close #76

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -822,6 +822,8 @@ subquestion: |
   <i class="fa fa-pen-alt" aria-hidden="true"></i> ${ signer } will sign on the document when you print it.
   % endfor
   
-  ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='lg') }
+  % if codefendants.number() > 0:
+  ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='md') }
+  % endif
   
 attachment code: motion_to_dismiss_for_non_essential_eviction

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -822,7 +822,7 @@ subquestion: |
   <i class="fa fa-pen-alt" aria-hidden="true"></i> ${ signer } will sign on the document when you print it.
   % endfor
   
-  % if codefendants.number() > 0:
+  % if len( remote_signers ) > 0:
   ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='md') }
   % endif
   


### PR DESCRIPTION
Feel free to close this if we don't want it. Same as #135 except this time hides button unless there are people who will be signing on a different device than the user. Extra test added. Closes #76.

Test 1:
- [x] User has 1 codef
- [x] User will text or email link to codef
- [x] User gets to final page
- [x] User sees a 'Check again' button

Test 2:
- [x] User has 0 codefs
- [x] User gets to final page
- [x] User sees no button

Test 3:
- [x] User has 3 codefs
- [x] User will sign for cod 1
- [x] Cod 2 will sign on user's device
- [x] Cod 3 will sign on paper copy
- [x] User gets to final page
- [x] User sees no button
