### PR TITLE
Implement improved court finder with no map. #131.

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -30,6 +30,7 @@ code: |
       ]
   preferred_court = "Housing Court"
   other_parties.there_are_any = True
+  user_role = 'defendant'
   interview_presets = True
 ---
 mandatory: True
@@ -435,22 +436,134 @@ template: placeholder_message
 content: |
   We won!
 ---
-id: court question
+if: |
+  # this should only be reached if the user's address is out of state
+  not len(all_matches)
 sets:
-  - courts[0].name
+  - courts[0]
+id: empty matches choose a court
 question: |
-  What court is your case being heard in?
+  ${ court_finder_question_template }
 subquestion: |
-  Look at your Summons and Complaint to find the name of the court
-  your case was filed in.
-
-  [FILE court-names.png]
+  ${ court_finder_defendant_instructions_template }
+  
+  ${ court_finder_additional_subquestion_content_template }
 fields:
-  - Court name: courts[0]
+  - no label: courts[0]
     datatype: object
-    choices: macourts.filter_courts(allowed_courts)
-    default: local_housing_court
-continue button field: ask_court_question    
+    object labeler: |
+      lambda y: y.short_label()
+    choices: macourts    
+help: 
+  label: |
+    How do I pick a court?
+  content: |
+    ${ court_finder_help_template }
+---
+if: |
+  len(all_matches)
+id: matching courts choose a court no map
+question: |
+  ${ court_finder_question_template }
+subquestion: |
+  ${ court_finder_defendant_instructions_template }
+  
+  ${ court_finder_additional_subquestion_content_template }
+fields:
+  - no label: courts[0]
+    datatype: object_radio
+    choices: all_matches
+    none of the above: True
+    disable others: True
+    object labeler: |
+      lambda y: y.short_description()
+    show if: 
+      code: |
+        len(all_matches)      
+  - note: |
+      Does the list above look wrong? If your case was filed in
+      a court we didn't list, choose from the full list below.
+    show if: 
+      code: |
+        len(all_matches)
+  - no label: courts[0]
+    datatype: object
+    object labeler: |
+      lambda y: y.short_label()
+    choices: macourts    
+help: 
+  label: |
+    How do I pick a court?
+  content: |
+    ${ court_finder_help_template }
+---
+template: court_finder_question_template
+content: |
+  % if users == plaintiffs:
+  What court do you want to file in?
+  % else:
+  What court is your case in?
+  % endif
+---
+template: court_finder_defendant_instructions_template
+content: |
+  % if not users == plaintiffs:
+  Look at your court paperwork. Match the name listed there.
+  % endif
+---
+template: court_finder_additional_subquestion_content_template
+content: |
+  [FILE court-names.png]
+---
+template: court_finder_defendant_instructions_template_text
+content: |
+  Look at your court paperwork. Match the name listed there.
+---
+template: court_finder_help_template
+content: |
+  For some cases, you can choose your court.
+
+  % if users == plaintiffs:
+  How do you know which court to choose?
+
+  Massachusetts has 7 trial court departments:
+
+  * District Court
+  * Boston Municipal Court (BMC)
+  * Superior Court
+  * Probate and Family Court
+  * Juvenile Court
+  * Housing Court
+  * Land Court
+
+  The District Court, BMC, and Superior Court are all courts that can hear
+  any type of case. Housing, Probate and Family and Juvenile Court are
+   **specialist** courts that hear one kind of case.
+  They have judges with special training as well as special 
+  resources available.
+
+  Different courts can make different kinds of decisions. Not every court
+  can give you every kind of help. For example, you can only
+  ask for visitation in the Probate and Family Court. Only
+  the Housing Court or Superior Court can hear discrimination
+  cases.
+
+  Depending on where you live, different courts may be further or closer to
+  your address. There are about 100 district courts all over the state,
+  but each county has only one or a few Superior Courts or specialty
+  courts.
+
+  Choosing a court means thinking about what kind of help you need, as well
+  as which court you can get transportation to on the day of your hearing.
+
+  Only you know the right choice.
+
+  You can also view the court selection guidance at [mass.gov](https://www.mass.gov/courthouse-locator).
+  % else:
+  If you are responding to a case someone else filed, you may not
+  get to choose your court. Select the court that is already
+  listed on your court paperwork.
+  % endif
 ---
 id: ready to serve
 question: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -447,7 +447,8 @@ fields:
   - no label: courts[0]
     datatype: object_radio
     choices: all_matches
-    none of the above: True
+    none of the above: |
+      My case is in another court
     disable others: True
     object labeler: |
       lambda court: court.short_description()
@@ -455,7 +456,7 @@ fields:
       code: |
         len(all_matches)      
   - note: |
-      Does the list above look wrong? If your case was filed in a court we didn't list, choose from the full list below.
+      Choose your court below.
     show if: 
       code: |
         len(all_matches)
@@ -476,9 +477,7 @@ sets:
 question: |
   What court is your case in?
 subquestion: |
-  Look at your court paperwork. Match the name listed there.
-  
-  [FILE court-names.png]
+  ${ court_choice_subquestion }
 fields:
   - no label: courts[0]
     datatype: object

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -39,19 +39,19 @@ code: |
   interview_presets
   
   # Skipping for speeding up tests
-  #no_court_email_massaccess_terms = True
-  #mtd_intro = True
-  #eviction_choice = "no"
-  #other_parties.target_number = '1'
-  #docket_numbers[0] = '111'
-  #users[0].name.first = 'd'
-  #users[0].name.last = 'd'
-  #users[0].address.address = '12 Dudley Street'
-  #users[0].address.unit = ''
-  #users[0].address.city = 'Boston'
-  #users[0].address.state = 'Massachusetts'
-  #users[0].address.zip = '02127'
-  #other_parties[0].name.first = 'v'
+  no_court_email_massaccess_terms = True
+  mtd_intro = True
+  eviction_choice = "no"
+  other_parties.target_number = '1'
+  docket_numbers[0] = '111'
+  users[0].name.first = 'd'
+  users[0].name.last = 'd'
+  users[0].address.address = '12 Dudley Street'
+  users[0].address.unit = ''
+  users[0].address.city = 'Boston'
+  users[0].address.state = 'Massachusetts'
+  users[0].address.zip = '02127'
+  other_parties[0].name.first = 'v'
   #codefendants[0].name.first = 'c'
   #codefendants[1].name.first = 'f'
   #codefendants[2].name.first = 's'
@@ -436,39 +436,13 @@ template: placeholder_message
 content: |
   We won!
 ---
-if: |
-  # this should only be reached if the user's address is out of state
-  not len(all_matches)
-sets:
-  - courts[0]
-id: empty matches choose a court
+id: choose a court no map
 question: |
-  ${ court_finder_question_template }
+  What court is your case in?
 subquestion: |
-  ${ court_finder_defendant_instructions_template }
+  Look at your court paperwork. Match the name listed there.
   
-  ${ court_finder_additional_subquestion_content_template }
-fields:
-  - no label: courts[0]
-    datatype: object
-    object labeler: |
-      lambda y: y.short_label()
-    choices: macourts    
-help: 
-  label: |
-    How do I pick a court?
-  content: |
-    ${ court_finder_help_template }
----
-if: |
-  len(all_matches)
-id: matching courts choose a court no map
-question: |
-  ${ court_finder_question_template }
-subquestion: |
-  ${ court_finder_defendant_instructions_template }
-  
-  ${ court_finder_additional_subquestion_content_template }
+  [FILE court-names.png]
 fields:
   - no label: courts[0]
     datatype: object_radio
@@ -476,94 +450,27 @@ fields:
     none of the above: True
     disable others: True
     object labeler: |
-      lambda y: y.short_description()
+      lambda court: court.short_description()
     show if: 
       code: |
         len(all_matches)      
   - note: |
-      Does the list above look wrong? If your case was filed in
-      a court we didn't list, choose from the full list below.
+      Does the list above look wrong? If your case was filed in a court we didn't list, choose from the full list below.
     show if: 
       code: |
         len(all_matches)
   - no label: courts[0]
     datatype: object
     object labeler: |
-      lambda y: y.short_label()
+      lambda court: court.short_label()
     choices: macourts    
 help: 
   label: |
     How do I pick a court?
   content: |
-    ${ court_finder_help_template }
----
-template: court_finder_question_template
-content: |
-  % if users == plaintiffs:
-  What court do you want to file in?
-  % else:
-  What court is your case in?
-  % endif
----
-template: court_finder_defendant_instructions_template
-content: |
-  % if not users == plaintiffs:
-  Look at your court paperwork. Match the name listed there.
-  % endif
----
-template: court_finder_additional_subquestion_content_template
-content: |
-  [FILE court-names.png]
----
-template: court_finder_defendant_instructions_template_text
-content: |
-  Look at your court paperwork. Match the name listed there.
----
-template: court_finder_help_template
-content: |
-  For some cases, you can choose your court.
-
-  % if users == plaintiffs:
-  How do you know which court to choose?
-
-  Massachusetts has 7 trial court departments:
-
-  * District Court
-  * Boston Municipal Court (BMC)
-  * Superior Court
-  * Probate and Family Court
-  * Juvenile Court
-  * Housing Court
-  * Land Court
-
-  The District Court, BMC, and Superior Court are all courts that can hear
-  any type of case. Housing, Probate and Family and Juvenile Court are
-   **specialist** courts that hear one kind of case.
-  They have judges with special training as well as special 
-  resources available.
-
-  Different courts can make different kinds of decisions. Not every court
-  can give you every kind of help. For example, you can only
-  ask for visitation in the Probate and Family Court. Only
-  the Housing Court or Superior Court can hear discrimination
-  cases.
-
-  Depending on where you live, different courts may be further or closer to
-  your address. There are about 100 district courts all over the state,
-  but each county has only one or a few Superior Courts or specialty
-  courts.
-
-  Choosing a court means thinking about what kind of help you need, as well
-  as which court you can get transportation to on the day of your hearing.
-
-  Only you know the right choice.
-
-  You can also view the court selection guidance at [mass.gov](https://www.mass.gov/courthouse-locator).
-  % else:
-  If you are responding to a case someone else filed, you may not
-  get to choose your court. Select the court that is already
-  listed on your court paperwork.
-  % endif
+    Select the court that is already listed on your court paperwork.
+    
+    [FILE court-names.png]
 ---
 id: ready to serve
 question: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -83,7 +83,12 @@ code: |
   users[0].mobile_number
   other_parties.target_number
   other_parties.gather()
-  courts[0]
+  # `standard_court_choice` does not get defined for in-state users
+  # if they select the `none of the above` option
+  show_choose_a_court
+  if defined('standard_court_choice'): courts[0] = standard_court_choice
+  else: courts[0] = custom_court_choice
+    
   docket_numbers[0]
   
   ready_to_serve
@@ -444,7 +449,7 @@ question: |
 subquestion: |
   ${ court_choice_subquestion }
 fields:
-  - no label: courts[0]
+  - no label: standard_court_choice
     datatype: object_radio
     choices: all_matches
     none of the above: |
@@ -452,19 +457,20 @@ fields:
     disable others: True
     object labeler: |
       lambda court: court.short_description()
-    show if: 
-      code: |
-        len(all_matches)      
   - note: |
       Choose your court below.
     show if: 
-      code: |
-        len(all_matches)
-  - no label: courts[0]
+      variable: standard_court_choice
+      is: null
+  - no label: custom_court_choice
     datatype: object
     object labeler: |
       lambda court: court.short_label()
     choices: macourts
+    show if: 
+      variable: standard_court_choice
+      is: null
+continue button field: show_choose_a_court
 ---
 # One reason this would be triggered is if someone had an
 # out-of-state address
@@ -473,17 +479,18 @@ if: |
   # this should only be reached if the user's address is out of state
   not len(all_matches)
 sets:
-  - courts[0]
+  - standard_court_choice
 question: |
   What court is your case in?
 subquestion: |
   ${ court_choice_subquestion }
 fields:
-  - no label: courts[0]
+  - no label: standard_court_choice
     datatype: object
     object labeler: |
       lambda court: court.short_label()
     choices: macourts
+continue button field: show_choose_a_court
 ---
 template: court_choice_subquestion
 content: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -436,13 +436,13 @@ template: placeholder_message
 content: |
   We won!
 ---
-id: choose a court no map
+id: matching courts choose a court no map
+if: |
+  len(all_matches)
 question: |
   What court is your case in?
 subquestion: |
-  Look at your court paperwork. Match the name listed there.
-  
-  [FILE court-names.png]
+  ${ court_choice_subquestion }
 fields:
   - no label: courts[0]
     datatype: object_radio
@@ -468,9 +468,45 @@ help:
   label: |
     How do I pick a court?
   content: |
-    Select the court that is already listed on your court paperwork.
-    
-    [FILE court-names.png]
+    ${ court_choice_help }
+---
+# One reason this would be triggered is if someone had an
+# out-of-state address
+id: empty matches choose a court no map
+if: |
+  # this should only be reached if the user's address is out of state
+  not len(all_matches)
+sets:
+  - courts[0]
+question: |
+  What court is your case in?
+subquestion: |
+  Look at your court paperwork. Match the name listed there.
+  
+  [FILE court-names.png]
+fields:
+  - no label: courts[0]
+    datatype: object
+    object labeler: |
+      lambda court: court.short_label()
+    choices: macourts    
+help: 
+  label: |
+    How do I pick a court?
+  content: |
+    ${ court_choice_help }
+---
+template: court_choice_subquestion
+content: |
+  Look at your court paperwork. Match the name listed there.
+  
+  [FILE court-names.png]
+---
+template: court_choice_help
+content: |
+  Select the court that is already listed on your court paperwork.
+  
+  [FILE court-names.png]
 ---
 id: ready to serve
 question: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -39,19 +39,19 @@ code: |
   interview_presets
   
   # Skipping for speeding up tests
-  no_court_email_massaccess_terms = True
-  mtd_intro = True
-  eviction_choice = "no"
-  other_parties.target_number = '1'
-  docket_numbers[0] = '111'
-  users[0].name.first = 'd'
-  users[0].name.last = 'd'
-  users[0].address.address = '12 Dudley Street'
-  users[0].address.unit = ''
-  users[0].address.city = 'Boston'
-  users[0].address.state = 'Massachusetts'
-  users[0].address.zip = '02127'
-  other_parties[0].name.first = 'v'
+  #no_court_email_massaccess_terms = True
+  #mtd_intro = True
+  #eviction_choice = "no"
+  #other_parties.target_number = '1'
+  #docket_numbers[0] = '111'
+  #users[0].name.first = 'd'
+  #users[0].name.last = 'd'
+  #users[0].address.address = '12 Dudley Street'
+  #users[0].address.unit = ''
+  #users[0].address.city = 'Boston'
+  #users[0].address.state = 'Massachusetts'
+  #users[0].address.zip = '02127'
+  #other_parties[0].name.first = 'v'
   #codefendants[0].name.first = 'c'
   #codefendants[1].name.first = 'f'
   #codefendants[2].name.first = 's'

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -463,12 +463,7 @@ fields:
     datatype: object
     object labeler: |
       lambda court: court.short_label()
-    choices: macourts    
-help: 
-  label: |
-    How do I pick a court?
-  content: |
-    ${ court_choice_help }
+    choices: macourts
 ---
 # One reason this would be triggered is if someone had an
 # out-of-state address
@@ -489,22 +484,11 @@ fields:
     datatype: object
     object labeler: |
       lambda court: court.short_label()
-    choices: macourts    
-help: 
-  label: |
-    How do I pick a court?
-  content: |
-    ${ court_choice_help }
+    choices: macourts
 ---
 template: court_choice_subquestion
 content: |
   Look at your court paperwork. Match the name listed there.
-  
-  [FILE court-names.png]
----
-template: court_choice_help
-content: |
-  Select the court that is already listed on your court paperwork.
   
   [FILE court-names.png]
 ---


### PR DESCRIPTION
Add some new court finder features - radio button list of court choices. Addresses #131, which also has other items in it.

Test 1 (does not complete):
1. 0 codefs
1. User enters a valid address
1. User gets to court finder and sees a radio button list of court choices

I only saw two choices for my court when I went through. I thought there were supposed to be three, so I was confused. Let me know if what I saw was a problem.

[Edit: The address for that was 12 Dudley Street, Boston, Massachusetts 02127]