### PR TITLE
Prevent unneeded message sending/number collection (version 1) #146

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -735,7 +735,6 @@ code: |
   # `action` experiments for true device choice begin here
   long_device_choice_url = interview_url_action( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
   device_choice_url = shortenMe( long_device_choice_url ).shortenedURL
-  qr_url = interview_url_action_as_qr( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
 ---
 code: |
   signature_data_id = get_random_chars()

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -735,7 +735,7 @@ code: |
   # `action` experiments for true device choice begin here
   long_device_choice_url = interview_url_action( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
   device_choice_url = shortenMe( long_device_choice_url ).shortenedURL
-  qr_url = interview_url_action_as_qr( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
+  #qr_url = interview_url_action_as_qr( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
 ---
 code: |
   signature_data_id = get_random_chars()

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -735,7 +735,7 @@ code: |
   # `action` experiments for true device choice begin here
   long_device_choice_url = interview_url_action( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
   device_choice_url = shortenMe( long_device_choice_url ).shortenedURL
-  #qr_url = interview_url_action_as_qr( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
+  qr_url = interview_url_action_as_qr( 'signature_with_device_choice', device_id='tbd', signature_data_id=signature_data_id, party_id=x.id )
 ---
 code: |
   signature_data_id = get_random_chars()

--- a/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
@@ -23,7 +23,8 @@ code: |
     x.signature.set_attributes(persistent=True, private=False)
     x.after_signature
   else:
-    x.device_number
+    if qr_url: x.saw_qr_code
+    else: x.device_number
     x.send_signature_link
     x.wait_for_signature
 ---
@@ -37,6 +38,7 @@ code: |
     # Reset and start over again
     undefine( x.attr_name( 'which_device' ))
     undefine( x.attr_name( 'send_method' ))
+    undefine( x.attr_name( 'saw_qr_code' ))
     undefine( x.attr_name( 'device_number' ))
     undefine( x.attr_name( 'send_signature_link' ))
     undefine( x.attr_name( 'wants_to_change_device' ))
@@ -125,22 +127,23 @@ code: |
 #question: |
 #  x.status
 ---
-id: send_method
-# Do not define `qr_url` as it should need id that can't be made here
-# for now, just get the mobile number
+id: send_method with qr code
+# Do not define `qr_url` as it should have an id that can't
+# be made here. Making a default url would, I think, be more
+# confusing to developers.
 generic object: Individual
 question: |
   Sign on a phone or tablet
 subquestion: |
-  % if qr_url:
   You can text yourself a link or you can use the QR code.
-  % endif
 fields:
+  - I want you to text me the link: should_text_singature_link
+    datatype: yesnowide
   - Number to text: x.device_number
     default: ${ showifdef( x.attr_name( 'mobile_number' )) }
     required: False
+    show if: should_text_singature_link
   - note: |
-      % if qr_url:
       ---
       
       To use this QR code:
@@ -152,7 +155,17 @@ fields:
       <center>
       ${ qr_url }
       </center>
-      % endif
+continue button field: x.saw_qr_code
+---
+# Must be below `x.saw_qr_code`
+id: send_method just phone
+generic object: Individual
+question: |
+  Sign on a phone or tablet
+fields:
+  - Number to text: x.device_number
+    default: ${ showifdef( x.attr_name( 'mobile_number' )) }
+    required: False
 ---
 code: |
   qr_url = False  # Fallback

--- a/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
@@ -23,8 +23,7 @@ code: |
     x.signature.set_attributes(persistent=True, private=False)
     x.after_signature
   else:
-    if qr_url: x.saw_qr_code
-    else: x.device_number
+    x.device_number
     x.send_signature_link
     x.wait_for_signature
 ---
@@ -38,7 +37,6 @@ code: |
     # Reset and start over again
     undefine( x.attr_name( 'which_device' ))
     undefine( x.attr_name( 'send_method' ))
-    undefine( x.attr_name( 'saw_qr_code' ))
     undefine( x.attr_name( 'device_number' ))
     undefine( x.attr_name( 'send_signature_link' ))
     undefine( x.attr_name( 'wants_to_change_device' ))
@@ -131,6 +129,7 @@ id: send_method with qr code
 # Do not define `qr_url` as it should have an id that can't
 # be made here. Making a default url would, I think, be more
 # confusing to developers.
+if: qr_url
 generic object: Individual
 question: |
   Sign on a phone or tablet
@@ -157,8 +156,8 @@ fields:
       </center>
 continue button field: x.saw_qr_code
 ---
-# Must be below `x.saw_qr_code`
 id: send_method just phone
+if: not qr_url
 generic object: Individual
 question: |
   Sign on a phone or tablet

--- a/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/sign_on_device.yml
@@ -125,11 +125,7 @@ code: |
 #question: |
 #  x.status
 ---
-id: send_method with qr code
-# Do not define `qr_url` as it should have an id that can't
-# be made here. Making a default url would, I think, be more
-# confusing to developers.
-if: qr_url
+id: link for mobile
 generic object: Individual
 question: |
   Sign on a phone or tablet
@@ -152,22 +148,9 @@ fields:
       1. Tap the pop-up notification.
       
       <center>
-      ${ qr_url }
+      [QR ${ device_choice_url }]
       </center>
 continue button field: x.saw_qr_code
----
-id: send_method just phone
-if: not qr_url
-generic object: Individual
-question: |
-  Sign on a phone or tablet
-fields:
-  - Number to text: x.device_number
-    default: ${ showifdef( x.attr_name( 'mobile_number' )) }
-    required: False
----
-code: |
-  qr_url = False  # Fallback
 ---
 id: x.wants_to_change_device
 generic object: Individual


### PR DESCRIPTION
If this design is accepted, it closes #146. It also simplifies the complex logic for the QR code.

- [x] Test 1
   - [x] 0 codefendants
   - [x] User starts on computer
   - [x] User gets to device choice for signature
   - [x] User chooses phone
   - [x] User users QR code to sign on phone
   - [x] User goes to computer and hits 'Next'
   - [x] Not sure (don't have a QR code reader). Ideally it goes to the 'Status' page, but it might go to wait for a signature. I think either works for MVP.
   - [x] User continues till end of interview

- [x] Test 2
   - [x] 0 codefendants
   - [x] User starts on computer
   - [x] User gets to device choice for signature
   - [x] User chooses phone
   - [x] User selects text themselves a link
   - [x] User hits 'Next'
   - [x] User gets text message
   - [x] User signs using texted link
   - [x] User continues till end of interview