### PR TITLE
Update to new #117 spec, try to improve editability of text

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -901,22 +901,22 @@ content: |
   You do not need ${ comma_and_list(unwilling_codefs) }'s signatures
   to file the motion.
 
-  * Download and file the motion. You can ask
+  * **Download and file the motion.** You can ask
   ${ comma_and_list(unwilling_codefs) } to sign the paper
   copy. If they do not sign the paper copy, cross out their
   names and file it anyway. Or,
-  * Start the interview again. Use the the 'Restart'
+  * **Start the interview again.** Use the the 'Restart'
   button. You can leave out ${ comma_and_list(unwilling_codefs) }.
   
   % elif len( unwilling_codefs ) > 0:
   You do not need ${ unwilling_codefs[0] }'s signature
   to file the motion.
 
-  * Download and file the motion. You can ask
+  * **Download and file the motion.** You can ask
   ${ unwilling_codefs[0] } to sign the paper
   copy. If they do not sign the paper copy, cross out their
   name and file it anyway. Or,
-  * Start the interview again. Use the the 'Restart'
+  * **Start the interview again.** Use the the 'Restart'
   button. You can leave out ${ unwilling_codefs[0] }.
   
   % endif

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -74,6 +74,7 @@ code: |
   
   codefendants.gather()
   # Set signers that will sign on this device or not
+  all_signers
   who_proxy_sign_for
   who_else_on_device
   local_signers  # codefendants signing on user's device
@@ -106,6 +107,10 @@ code: |
 ---
 code: |
   all_signers = users + codefendants
+---
+reconsider:
+  - all_signers
+code: |
   who_sign_with_pen = [codef for codef in codefendants if codef.sign_method == 'physical']
   all_digital_codefs = [codef for codef in codefendants if codef not in who_sign_with_pen]
   # Get signatures that will taken on this device
@@ -115,6 +120,9 @@ code: |
   # Used in here and for sending out for signatures (multiuser code)
   remote_signers = all_signers.difference(local_signers + who_sign_with_pen)
   collect_signer_types = True
+---
+code: |
+  unwilling_codefs = [signer for signer in codefendants if hasattr(signer, 'willing_to_sign') and signer.willing_to_sign is False]
 ---
 # After the user signs, the links for the co-signers get sent
 event: x.after_signature
@@ -809,8 +817,8 @@ code: |
 #################
 id: if all signed send email
 reconsider:
-  - collect_signer_types
   - get_stored_data
+  - collect_signer_types
 # Is requested when people check on the status of the signatures
 code: |
   # Statuses: sent, signed, unwilling, physical
@@ -826,8 +834,9 @@ code: |
 id: signature status
 event: users[0].status
 reconsider:
-  - collect_signer_types
   - get_stored_data
+  - collect_signer_types
+  - unwilling_codefs
   - all_signatures_in
   - motion_to_dismiss_for_non_essential_eviction
   - final_form
@@ -840,47 +849,102 @@ question: |
 subquestion: |
 
   % if all_signatures_in:
-  
-    % if len( all_digital_codefs ) > 1:
-    <i class="fa fa-check" aria-hidden="true"></i> ${ comma_and_list( all_digital_codefs )} have signed.
-    % elif len( all_digital_codefs ) > 0:
-    <i class="fa fa-check" aria-hidden="true"></i> ${ all_digital_codefs[0] } has signed.
-    % endif
-  
+    ${ every_digital_signature_in_template }
+    
   % else:
   
-    <% unwilling_exists = False %>
-    % for signer in codefendants:
-    % if defined( signer.attr_name( 'willing_to_sign' )) and signer.willing_to_sign is False:
-    <% unwilling_exists = True %>
-    <i class="fa fa-times" aria-hidden="true"></i> ${ signer } refused to sign your motion. We sent it to ${ signer } at **${ showifdef( signer.attr_name('signature_email' )) }${ showifdef(signer.attr_name('signature_number' )) }**. If  ${ signer } does not want to sign the motion, you can still print or download it without  ${ signer }'s signature and file it with the court.[BR]
-    % endif
-    % endfor
-    
-    % if unwilling_exists:
+    % if len( unwilling_codefs ) > 0:
+    ${ unwilling_list_template }
+
+    ${ unwilling_instructions }
     ---
     % endif
 
-    % for signer in remote_signers:
-    % if not defined( signer.attr_name( 'signature' )) and (not defined( signer.attr_name( 'willing_to_sign' )) or not signer.willing_to_sign is False):
-    <i class="fa fa-envelope" aria-hidden="true"></i> You sent a message to ${ signer } to sign. They have not signed yet.[BR]
-    % endif
-    % endfor
-  
-    % for signer in codefendants:
-    % if defined( signer.attr_name( 'signature' )):
-    <i class="fa fa-check" aria-hidden="true"></i> ${ signer } has signed[BR]
-    % endif
-    % endfor
+    ${ waiting_list_template }
+
+    ${ signed_list_template }
   
   % endif
   
-  % for signer in who_sign_with_pen:
-  <i class="fa fa-pen-alt" aria-hidden="true"></i> ${ signer } will sign on the document when you print it.
-  % endfor
+  ${ paper_signature_list_template }
   
   % if len( remote_signers ) > 0:
   ${ action_button_html('javascript:daShowSpinner();daRefreshSubmit()', label='Check again <i class="fas fa-sync-alt"></i>', size='md') }
   % endif
+
+buttons:
+  - Restart: restart
   
 attachment code: motion_to_dismiss_for_non_essential_eviction
+---
+# Edit below to change the contents of the status page
+---
+template: every_digital_signature_in_template
+content: |
+  % if len( all_digital_codefs ) > 1:
+  :check: ${ comma_and_list( all_digital_codefs )} have signed.
+  % elif len( all_digital_codefs ) > 0:
+  :check: ${ all_digital_codefs[0] } has signed.
+  % endif
+---
+template: unwilling_list_template
+content: |
+  % for signer in unwilling_codefs:
+  :times: ${ signer } refused to sign your motion. We sent it to ${ signer } at **${ signer.signature_message_endpoint }**. If ${ signer } does not want to sign the motion, you can still print or download it without ${ signer }'s signature and file it with the court.[BR]
+  % endfor
+---
+template: unwilling_instructions
+content: |
+  % if len( unwilling_codefs ) > 1:
+  You do not need ${ comma_and_list(unwilling_codefs) }'s signatures
+  to file the motion.
+
+  * Download and file the motion. You can ask
+  ${ comma_and_list(unwilling_codefs) } to sign the paper
+  copy. If they do not sign the paper copy, cross out their
+  names and file it anyway. Or,
+  * Start the interview again. Use the the 'Restart'
+  button. You can leave out ${ comma_and_list(unwilling_codefs) }.
+  
+  % elif len( unwilling_codefs ) > 0:
+  You do not need ${ unwilling_codefs[0] }'s signature
+  to file the motion.
+
+  * Download and file the motion. You can ask
+  ${ unwilling_codefs[0] } to sign the paper
+  copy. If they do not sign the paper copy, cross out their
+  name and file it anyway. Or,
+  * Start the interview again. Use the the 'Restart'
+  button. You can leave out ${ unwilling_codefs[0] }.
+  
+  % endif
+---
+template: waiting_list_template
+content: |
+  % for signer in remote_signers:
+  % if not defined( signer.attr_name( 'signature' )) and (not defined( signer.attr_name( 'willing_to_sign' )) or not signer.willing_to_sign is False):
+  :envelope: You sent a message to ${ signer } at ${ signer.signature_message_endpoint } to sign the document. They have not signed yet.[BR]
+  % endif
+  % endfor
+---
+template: signed_list_template
+content: |
+  % for signer in codefendants:
+  % if defined( signer.attr_name( 'signature' )):
+  :check: ${ signer } has signed[BR]
+  % endif
+  % endfor
+---
+template: paper_signature_list_template
+content: |
+  % for signer in who_sign_with_pen:
+  :pen-alt: ${ signer } will sign on the document when you print it.[BR]
+  % endfor
+---
+# `template` so it gets recalculated each time (I think)
+# Separate so it can be reused and the text for it can be easily edited.
+generic object: Individual
+template: x.signature_message_endpoint
+content: |
+  ${ x.signature_email if x.send_method == "email" else x.signature_number }
+---

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -890,7 +890,7 @@ content: |
 template: unwilling_list_template
 content: |
   % for signer in unwilling_codefs:
-  :times: ${ signer } refused to sign your motion. We sent it to ${ signer } at **${ signer.signature_message_endpoint }**. If ${ signer } does not want to sign the motion, you can still print or download it without ${ signer }'s signature and file it with the court.[BR]
+  :times: ${ signer } refused to sign your motion. We sent it to ${ signer } at **${ signer.signature_message_endpoint }**.[BR]
   % endfor
 ---
 template: unwilling_instructions
@@ -922,7 +922,7 @@ content: |
 template: waiting_list_template
 content: |
   % for signer in remote_signers:
-  % if not defined( signer.attr_name( 'signature' )) and (not defined( signer.attr_name( 'willing_to_sign' )) or not signer.willing_to_sign is False):
+  % if not hasattr(signer, 'signature') and (not hasattr(signer,'willing_to_sign') or not signer.willing_to_sign is False):
   :envelope: You sent a message to ${ signer } at ${ signer.signature_message_endpoint } to sign the document. They have not signed yet.[BR]
   % endif
   % endfor
@@ -930,7 +930,7 @@ content: |
 template: signed_list_template
 content: |
   % for signer in codefendants:
-  % if defined( signer.attr_name( 'signature' )):
+  % if hasattr(signer, 'signature'):
   :check: ${ signer } has signed[BR]
   % endif
   % endfor

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -831,6 +831,7 @@ code: |
     all_signatures_in = True
   get_status_of_signatures = True
 ---
+# Each variable is a chunk of text. Be aware of the `if` statements and move things around as you see fit.
 id: signature status
 event: users[0].status
 reconsider:
@@ -890,7 +891,8 @@ content: |
 template: unwilling_list_template
 content: |
   % for signer in unwilling_codefs:
-  :times: ${ signer } refused to sign your motion. We sent it to ${ signer } at **${ signer.signature_message_endpoint }**.[BR]
+  :times: ${ signer } refused to sign your motion. We sent 
+  it to ${ signer } at **${ signer.signature_message_endpoint }**.[BR]
   % endfor
 ---
 template: unwilling_instructions
@@ -923,7 +925,9 @@ template: waiting_list_template
 content: |
   % for signer in remote_signers:
   % if not hasattr(signer, 'signature') and (not hasattr(signer,'willing_to_sign') or not signer.willing_to_sign is False):
-  :envelope: You sent a message to ${ signer } at ${ signer.signature_message_endpoint } to sign the document. They have not signed yet.[BR]
+  :envelope: You sent a message to ${ signer } at
+  ${ signer.signature_message_endpoint } to sign the
+  document. They have not signed yet.[BR]
   % endif
   % endfor
 ---


### PR DESCRIPTION
Implement new spec for wording in #117. There are questions outstanding in Slack.

- [ ] Test 1:
   - [x] User has 4 codefendants
   - [x] co1 will sign by text or email (give your real info)
   - [x] co2 will sign by text or email (give your real info)
   - [x] co3 will sign on paper
   - [x] co4 will sign on paper
   - [x] User does not need to give their real contact info
   - [x] User signs
   - [x] On the status page, user sees two envelopes and two pens
   - [x] co1 is unwilling to sign
   - [x] User will have to refresh after each codef action. On the status page, user sees one `x`, unwilling signer (singular) instructions, one envelope, and two pens
   - [x] co2 is unwilling to sign
   - [x] On the status page, user sees two `x`s, unwilling signers (plural) instructions, and two pens
   - [x] co1 signs
   - [x] On the status page, user sees one `x`, unwilling signer (singular) instructions, one checkmark, and two pens
   - [x] co2 signs
   - [x] On the status page, user sees a checkmark with one line with co1 and co2 names listed, as well as two pens
