### PR TITLE
Close #141, close #140, close #139, language and behavior

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -636,6 +636,19 @@ attachment:
   filename: dismiss-non-essential-eviction
   name: Motion to Dismiss - Non-Essential Eviction
 ---
+# Only triggered for signers who user is signing for.
+# Using intrinsic names is not enough.
+id: persons signature
+generic object: Individual
+if: |
+  x in who_proxy_sign_for
+question: |
+  ${ users[0] }, sign with the permisson of ${ x }
+signature: x.signature
+under: |
+  ${ x }
+progress: 99
+---
 include:
   - multipleusers.yml
 ---

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -391,7 +391,9 @@ fields:
   - Middle Name: codefendants[i].name.middle
     required: False
   - Last Name: codefendants[i].name.last
-  - Suffix: codefendants[i].name.suffix
+  - Suffix: users[0].name.suffix
+    code: |
+      name_suffix()
     required: False
 ---
 id: how to send to codefendant

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -724,7 +724,7 @@ id: all signed email template
 reconsider:
   - final_form
 template: final_email_template
-subject: Your Eviction Moratorium is ready to print or email
+subject: Your Motion to Dismiss is ready to print or email
 content: |
   ${ users[0] },
 
@@ -833,9 +833,9 @@ reconsider:
   - final_form
 question: |
   % if all_signatures_in:
-  Your Eviction Moratorium is ready to print or email
+  Your Motion to Dismiss is ready to print or email
   % else:
-  Some people still need to sign your Eviction Moratorium
+  Some people still need to sign your Motion to Dismiss
   % endif
 subquestion: |
 

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -391,7 +391,7 @@ fields:
   - Middle Name: codefendants[i].name.middle
     required: False
   - Last Name: codefendants[i].name.last
-  - Suffix: users[0].name.suffix
+  - Suffix: codefendants[i].name.suffix
     code: |
       name_suffix()
     required: False

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -391,7 +391,6 @@ fields:
   - Middle Name: codefendants[i].name.middle
     required: False
   - Last Name: codefendants[i].name.last
-    required: False
   - Suffix: codefendants[i].name.suffix
     required: False
 ---


### PR DESCRIPTION
To make testing easier, I'm experimenting with combining previous PRs so they can all be tested in one test. Tell me how it goes!

1. Copy new basic-questions name code for codef. Close #139
1. Close #140, different signing page text when user signing for codef
1. Replace 'Eviction Moratorium' with 'Motion to Dismiss' from status page and final email. Close #141

- [ ] Test 1:
   - [x] 3 codefs
   - [x] When user enters a codef name, first and last name are required. Suffix choices are dropdown.
   - [x] co1 will sign on same device
   - [x] User will sign for co2
   - [x] co3 will get text or email (needs to be your real info that you can check)
   - [x] User gives real email address too
   - [x] Preview has correct names for codef
   - [x] User gets to signatures
   - [x] Correct text shows for each signer (co2 should say '${user}, sign with permission of ${signer}')
   - [x] User gets to status page. Does not see 'Eviction Moratorium'. Does see 'Motion to Dismiss'.
   - [x] co1 signs
   - [x] User hits 'Check again'
   - [x] User looks at new final screen text. Does not see 'Eviction Moratorium'. Does see 'Motion to Dismiss'
   - [x] User gets final email. Does not see 'Eviction Moratorium'. Does see 'Motion to Dismiss'
