### PR TITLE
Improve instructions about unwilling codefendants. Closes #164

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -975,26 +975,28 @@ content: |
 template: unwilling_instructions
 content: |
   % if len( unwilling_codefs ) > 1:
-  You do not need ${ comma_and_list(unwilling_codefs) }'s signatures
-  to file the motion.
+  **You do not need ${ comma_and_list(unwilling_codefs) }'s signatures
+  to file the motion**
 
-  * **Download and file the motion.** You can ask
+  * Download and file the motion. You can ask
   ${ comma_and_list(unwilling_codefs) } to sign the paper
-  copy. If they do not sign the paper copy, cross out their
-  names and file it anyway. Or,
-  * **Start the interview again.** Use the the 'Restart'
-  button. You can leave out ${ comma_and_list(unwilling_codefs) }.
+  copy. If they do not sign the paper copy, you can cross out their
+  names and file it anyway. **Or,**
+  * Start the interview again. Use the the 'Restart'
+  button. You can leave out ${ comma_and_list(unwilling_codefs) }. **Or,**
+  * You can file the motion as it is.
   
   % elif len( unwilling_codefs ) > 0:
-  You do not need ${ unwilling_codefs[0] }'s signature
-  to file the motion.
+  **You do not need ${ unwilling_codefs[0] }'s signature
+  to file the motion. You can:**
 
-  * **Download and file the motion.** You can ask
+  * Download and file the motion. You can ask
   ${ unwilling_codefs[0] } to sign the paper
-  copy. If they do not sign the paper copy, cross out their
-  name and file it anyway. Or,
-  * **Start the interview again.** Use the the 'Restart'
-  button. You can leave out ${ unwilling_codefs[0] }.
+  copy. If they do not sign the paper copy, you can cross out their
+  name and file it anyway. **Or,**
+  * Start the interview again. Use the the 'Restart'
+  button. You can leave out ${ unwilling_codefs[0] }. **Or,**
+  * You can file the motion as it is.
   
   % endif
 ---

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -976,7 +976,7 @@ template: unwilling_instructions
 content: |
   % if len( unwilling_codefs ) > 1:
   **You do not need ${ comma_and_list(unwilling_codefs) }'s signatures
-  to file the motion**
+  to file the motion. You can:**
 
   * Download and file the motion. You can ask
   ${ comma_and_list(unwilling_codefs) } to sign the paper

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -982,7 +982,7 @@ content: |
   ${ comma_and_list(unwilling_codefs) } to sign the paper
   copy. If they do not sign the paper copy, you can cross out their
   names and file it anyway. **Or,**
-  * Start the interview again. Use the the 'Restart'
+  * Start the interview again. Use the 'Restart'
   button. You can leave out ${ comma_and_list(unwilling_codefs) }. **Or,**
   * You can file the motion as it is.
   
@@ -994,7 +994,7 @@ content: |
   ${ unwilling_codefs[0] } to sign the paper
   copy. If they do not sign the paper copy, you can cross out their
   name and file it anyway. **Or,**
-  * Start the interview again. Use the the 'Restart'
+  * Start the interview again. Use the 'Restart'
   button. You can leave out ${ unwilling_codefs[0] }. **Or,**
   * You can file the motion as it is.
   


### PR DESCRIPTION
Improve instructions about unwilling codefendants. Closes #164

- [x] Test 1:
   - [x] 1 codef
   - [x] User sends codef link
   - [x] User gets to end
   - [x] Codef refuses to sign
   - [x] User checks again sees correct (singular) 'unwilling' instructions (3 options, etc)

- [x] Test 2:
   - [x] 2 codef
   - [x] User sends both codefs link
   - [x] User gets to end
   - [x] Codefs both refuse to sign
   - [x] User checks again sees correct (plural) 'unwilling' instructions (3 options, etc)
   