### PR TITLE
Ensure (as best we can) that urls in texts aren't split. Close #187

### DIFF
--- a/docassemble/MAEvictionMoratorium/data/questions/parent_interview_redis_handler.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/parent_interview_redis_handler.yml
@@ -37,7 +37,7 @@ code: |
   parties = {}
   for signer in all_signers:
     parties[ signer.id ] = {
-      "has_signed": False, "willing_to_sign": None, "name": str( signer )
+      "has_signed": False, "willing_to_sign": None, "name": signer.name
     }
   signature_data[ 'parties' ] = parties
   

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -759,7 +759,11 @@ code: |
 id: cosigner links sent notification sms
 template: initial_sms_template
 content: |
-  ${ users[0] }, your Motion to Dismiss was sent to ${ comma_and_list( remote_signers ) }. See the document at ${ interview_url_action('check_status', party_id=users[0].id) }
+  % if len(remote_signers) > 1:
+  ${ users[0].familiar() }, we sent your Motion to Dismiss to your codefendants. Use the link to see your document. ${ shortenMe(interview_url_action('check_status', party_id=users[0].id)).shortenedURL }
+  % else:
+  ${ users[0].familiar() }, we sent your Motion to Dismiss to your codefendant. Use the link to see your document. ${ shortenMe(interview_url_action('check_status', party_id=users[0].id)).shortenedURL }
+  % endif
 ---
 id: cosigner links sent notification email
 template: initial_email_template

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -717,7 +717,7 @@ code: |
 id: sms template multiuser
 template: codefendants[i].sms_template
 content: |
-  ${ codefendants[i].familiar() }, please review and sign ${ users[0].familiar() }’s Motion to Dismiss at this link. ${ codefendants[i].cosigner_url }
+  ${ codefendants[i].familiar() }, please review and sign ${ users[0].familiar() }’s Motion to Dismiss. Use this link. ${ codefendants[i].cosigner_url }
 ---
 id: codefendant email
 reconsider:

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -717,7 +717,7 @@ code: |
 id: sms template multiuser
 template: codefendants[i].sms_template
 content: |
-  ${ codefendants[i].familiar() }, please review and sign ${ users[0].familiar() }’s Motion to Dismiss. Use this link. ${ codefendants[i].cosigner_url }
+  ${ codefendants[i].familiar() }, please review and sign ${ users[0].familiar() }’s motion about your eviction case. Use this link. ${ codefendants[i].cosigner_url }
 ---
 id: codefendant email
 reconsider:

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -863,7 +863,7 @@ code: |
 generic object: Individual
 template: x.sms_device_template
 content:
-  ${ x }, tap the link to sign your Motion to Dismiss. ${ device_choice_url }
+  ${ x.familiar() }, tap the link to sign your Motion to Dismiss. ${ device_choice_url }
 ---
 generic object: Individual
 code: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -863,9 +863,7 @@ code: |
 generic object: Individual
 template: x.sms_device_template
 content:
-  ${ x }, tap the link to sign your Motion to Dismiss.
-
-  ${ device_choice_url }
+  ${ x }, tap the link to sign your Motion to Dismiss. ${ device_choice_url }
 ---
 generic object: Individual
 code: |

--- a/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/prose_mtd_non_emergency_merge.yml
@@ -717,9 +717,7 @@ code: |
 id: sms template multiuser
 template: codefendants[i].sms_template
 content: |
-  Dear ${ codefendants[i] },
-  ${ users[0] } filled out a Motion to Dismiss your eviction case. Please review and sign if you want to file it with ${ users[0] }.  
-  ${ codefendants[i].cosigner_url }
+  ${ codefendants[i].familiar() }, please review and sign ${ users[0].familiar() }’s Motion to Dismiss at this link. ${ codefendants[i].cosigner_url }
 ---
 id: codefendant email
 reconsider:

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -137,7 +137,7 @@ content: |
 ---
 template: signed_sms_template
 content: |
-  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } has signed your Motion to Dismiss. Use the link to see your document. ${ redis.get_data( signature_data_id )['interview_url'] }
+  ${ signer.familiar() } has signed your Motion to Dismiss. Use the link to see your document. ${ redis.get_data( signature_data_id )['interview_url'] }
 ---
 id: x.after_unwilling_to_sign_saved
 event: x.after_unwilling_to_sign_saved
@@ -176,7 +176,7 @@ content: |
 ---
 template: unwilling_sms_template
 content: |
-  ${ redis.get_data( signature_data_id )['user_names'] }, ${ signer } will not sign your Motion to Dismiss a Non-Essential Eviction. Tap the link to see your document's status. ${ redis.get_data( signature_data_id )['interview_url'] }
+  ${ signer.familiar() } will not sign your Motion to Dismiss. Use the link to see your document. ${ redis.get_data( signature_data_id )['interview_url'] }
 ---
 ###################
 # Interfacing directly with script for user choosing other device to sign on

--- a/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
+++ b/docassemble/MAEvictionMoratorium/data/questions/remote_signer_entrypoint.yml
@@ -204,7 +204,7 @@ signature: x.signature
 generic object: Individual
 template: x.sms_device_template
 content:
-  You have chosen to sign on this device, ${ x }. ${ device_choice_url }
+  ${ x.familiar() }, use this link to sign. ${ device_choice_url }
 ---
 id: remote signer end
 generic object: Individual

--- a/docassemble/MAEvictionMoratorium/signing_party.py
+++ b/docassemble/MAEvictionMoratorium/signing_party.py
@@ -85,7 +85,7 @@ def set_signer_attributes( signer, signature_data_id, party_id ):
   
   if party_data:
     signer.valid = True
-    signer.name.first = party_data['name']
+    signer.name = party_data['name']
     signer.has_signed = party_data['has_signed']
     signer.was_willing = party_data['willing_to_sign']
     #for key, value in party_data.items():


### PR DESCRIPTION
Ensure (as best we can) that urls in texts aren't split. Close #187

For all tests, always use real phone number (the one Caroline has that breaks the text messages) and the texted url should be whole and working.

- [x] Test 1:
   - [x] 1 codef
   - [x] User starts on computer
   - [x] User texts codef at real number
   - [x] User (when choosing a device) selects to sign on phone
   - [x] User gets message on phone and signs on phone
   - [x] Codef checks that texted message looks right, but opens link on COMPUTER
   - [x] Codef says unwilling to sign (only codef's first name is displayed)
   - [x] User gets text that codef is unwilling to sign
   - [x] Codef restarts/reopens interview on COMPUTER
   - [x] Codef (when choosing a device) chooses to sign on phone
   - [x] Codef opens message on phone and signs on phone
   - [x] User gets text that codef has signed (only codef's first name is displayed)
