### PR TITLE
Add test for shortest path and kickout screens. Develop testing framework.

### DIFF
--- a/tests/features/foo.feature
+++ b/tests/features/foo.feature
@@ -1,0 +1,37 @@
+Feature: Shortest path with all possible information
+
+- [ ] Take the shortest path
+- [ ] Give most info possible
+- [ ] Check for singulars
+
+Scenario: Shortest path
+  Given I start the interview
+  When I tap the option with the text "I accept"
+  When I tap the button "Next"
+  When I tap the button "Next"
+  Then I type "Ulli" in the "First Name" field
+  Then I type "Umiddle" in the "Middle Name" field
+  Then I type "User" in the "Last Name" field
+  Then I select "Jr" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I tap the option with the text "I am filing this motion alone."
+  Then I tap the button "Next"
+  Then I tap the option with the text "No, I am not risking anyone’s health or safety"
+  Then I tap the button "Next"
+  Then I type "112 Southampton St" in the "Street address" field
+  Then I type "1" in the "Unit" field
+  Then I type "Boston" in the "City" field
+  Then I select "Massachusetts" from the "State" dropdown
+  Then I type "02118" in the "Zip" field
+  Then I tap the button "Next"
+  Then I type "201 555-0123" in the "Mobile number" field
+  Then I type "202 555-0123" in the "Other phone number" field
+  Then I type "user@example.com" in the "Email address" field
+  Then I type "Semaphore" in the "Other ways to reach you" field
+  Then I tap the button "Next"
+  Then I do nothing
+  Then I tap the button "Next"
+  Then I type "Landlord 1" in the unlabeled field
+  Then I tap the button "Next"
+  Then I select "Attleboro District Court" from the dropdown
+  Then I tap the button "Next"

--- a/tests/features/foo.feature
+++ b/tests/features/foo.feature
@@ -42,6 +42,6 @@ Scenario: Shortest path
   Then I wait 2 seconds
   Then I tap the button "Next"
   Then I tap the button "This computer"
-  Then the question id should be "persons signature"
   Then I sign
-  Then I tap the button "Next"
+  When I tap the button "Next"
+  Then the question id should be "signature status"

--- a/tests/features/foo.feature
+++ b/tests/features/foo.feature
@@ -35,3 +35,13 @@ Scenario: Shortest path
   Then I tap the button "Next"
   Then I select "Attleboro District Court" from the dropdown
   Then I tap the button "Next"
+  Then I type "111" in the "Docket number" field
+  Then I tap the button "Next"
+  Then I choose "No"
+  Then I tap the button "Next"
+  Then I wait 2 seconds
+  Then I tap the button "Next"
+  Then I tap the button "This computer"
+  Then the question id should be "persons signature"
+  Then I sign
+  Then I tap the button "Next"

--- a/tests/features/kickout.feature
+++ b/tests/features/kickout.feature
@@ -14,8 +14,8 @@ Scenario: Single person gets kicked out for harm
   Then I tap the button "Next"
   Then I tap the option with the text "Yes, I am risking someone’s health or safety"
   Then I tap the button "Next"
-  Then I should NOT see the phrase "any of your codefendants"
   Then the question id should be "kick out"
+  Then I should NOT see the phrase "any of your codefendants"
 
 Scenario: Multiple people gets kicked out for harm
   Given I start the interview

--- a/tests/features/kickout.feature
+++ b/tests/features/kickout.feature
@@ -1,0 +1,41 @@
+Feature: Get kicked out if evicted for harm
+
+There's only one kickout in this interview.
+
+Scenario: Single person gets kicked out for harm
+  Given I start the interview
+  When I tap the option with the text "I accept"
+  When I tap the button "Next"
+  When I tap the button "Next"
+  Then I type "Ulli" in the "First Name" field
+  Then I type "User" in the "Last Name" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "I am filing this motion alone."
+  Then I tap the button "Next"
+  Then I tap the option with the text "Yes, I am risking someone’s health or safety"
+  Then I tap the button "Next"
+  Then I should NOT see the phrase "any of your codefendants"
+  Then the question id should be "kick out"
+
+Scenario: Multiple people gets kicked out for harm
+  Given I start the interview
+  When I tap the option with the text "I accept"
+  When I tap the button "Next"
+  When I tap the button "Next"
+  Then I type "Ulli" in the "First Name" field
+  Then I type "User" in the "Last Name" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "I talked to them and at least one of them wants to file with me."
+  Then I tap the button "Next"
+  Then I type "Cod 1" in the "First Name" field
+  Then I type "Codef" in the "Last Name" field
+  Then I tap the button "Next"
+  Then I tap the button "Next"
+  Then I tap the option with the text "with me at the end"
+  Then I tap the button "Next"
+  Then I tap the button "No"
+  Then I tap the option with the text "Yes, we are risking someone’s health or safety"
+  When I tap the button "Next"
+  Then the question id should be "kick out"
+  Then I SHOULD see the phrase "any of your codefendants"
+

--- a/tests/features/shortest_path.feature
+++ b/tests/features/shortest_path.feature
@@ -1,8 +1,6 @@
 Feature: Shortest successful path with all possible information
 
-- [x] Take the shortest path
-- [x] Give most info possible
-- [ ] Check for singulars
+- [x] Take the shortest path, give most info possible, check for singulars
 
 Scenario: Shortest successful path
   Given I start the interview

--- a/tests/features/shortest_path.feature
+++ b/tests/features/shortest_path.feature
@@ -1,10 +1,10 @@
-Feature: Shortest path with all possible information
+Feature: Shortest successful path with all possible information
 
-- [ ] Take the shortest path
-- [ ] Give most info possible
+- [x] Take the shortest path
+- [x] Give most info possible
 - [ ] Check for singulars
 
-Scenario: Shortest path
+Scenario: Shortest successful path
   Given I start the interview
   When I tap the option with the text "I accept"
   When I tap the button "Next"
@@ -16,7 +16,7 @@ Scenario: Shortest path
   Then I tap the button "Next"
   Then I tap the option with the text "I am filing this motion alone."
   Then I tap the button "Next"
-  Then I tap the option with the text "No, I am not risking anyone’s health or safety"
+  Then I tap the option with the text "No, I am not risking someone's health or safety"
   Then I tap the button "Next"
   Then I type "112 Southampton St" in the "Street address" field
   Then I type "1" in the "Unit" field

--- a/tests/features/shortest_path.feature
+++ b/tests/features/shortest_path.feature
@@ -16,7 +16,7 @@ Scenario: Shortest successful path
   Then I tap the button "Next"
   Then I tap the option with the text "I am filing this motion alone."
   Then I tap the button "Next"
-  Then I tap the option with the text "No, I am not risking someone's health or safety"
+  Then I tap the option with the text "No, I am not risking anyone’s health or safety"
   Then I tap the button "Next"
   Then I type "112 Southampton St" in the "Street address" field
   Then I type "1" in the "Unit" field
@@ -31,6 +31,7 @@ Scenario: Shortest successful path
   Then I tap the button "Next"
   Then I do nothing
   Then I tap the button "Next"
+  Then I should see the phrase "What is the plaintiff’s name?"
   Then I type "Landlord 1" in the unlabeled field
   Then I tap the button "Next"
   Then I select "Attleboro District Court" from the dropdown

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -42,7 +42,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 
 const INTERVIEW_URL = interviewConstants.INTERVIEW_URL;
-setDefaultTimeout(80 * 1000);
+setDefaultTimeout(120 * 1000);
 
 let device_touch_map = {
   mobile: 'tap',
@@ -59,7 +59,7 @@ Given(/I start the interview[ on ]?(.*)/, async (optional_device) => {
 
   if (!scope.page) {
     scope.page = await scope.browser.newPage();
-    scope.page.setDefaultTimeout(80 * 1000)
+    scope.page.setDefaultTimeout(120 * 1000)
   }
 
   // Let developer pick mobile device if they want to
@@ -97,7 +97,8 @@ When("I do nothing", async () => {
   await scope.afterStep(scope);
 });
 
-Then('I should see the phrase {string}', async (phrase) => {
+// Allow emphasis with capital letters
+Then(/I should see the phrase "([^"]+)"/i, async (phrase) => {
   /* In Chrome, this `innerText` gets only visible text */
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
   expect(bodyText).to.contain(phrase);
@@ -105,7 +106,8 @@ Then('I should see the phrase {string}', async (phrase) => {
   await scope.afterStep(scope);
 });
 
-Then('I should not see the phrase {string}', async (phrase) => {
+// Allow emphasis with capital letters
+Then(/I should not see the phrase "([^"]+)"/i, async (phrase) => {
   /* In Chrome, this `innerText` gets only visible text */
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
   expect(bodyText).not.to.contain(phrase);
@@ -376,7 +378,7 @@ When(/I tap the option with the text "([^"]+)"/, async (label_text) => {
   *    its text has to match exactly and it turns out taping labels
   *    works for more than one thing.
   */
-  let choice = await scope.page.waitFor( `label[aria-label*="${ label_text }"]` );
+  let choice = await scope.page.waitForSelector( `label[aria-label*="${ label_text }"]` );
   await choice[ scope.click_type[ scope.device ]]();
 
   await scope.afterStep(scope, {waitForShowIf: true});

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -42,7 +42,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 
 const INTERVIEW_URL = interviewConstants.INTERVIEW_URL;
-setDefaultTimeout(50 * 1000);
+setDefaultTimeout(80 * 1000);
 
 let device_touch_map = {
   mobile: 'tap',
@@ -59,7 +59,7 @@ Given(/I start the interview[ on ]?(.*)/, async (optional_device) => {
 
   if (!scope.page) {
     scope.page = await scope.browser.newPage();
-    scope.page.setDefaultTimeout(50 * 1000)
+    scope.page.setDefaultTimeout(80 * 1000)
   }
 
   // Let developer pick mobile device if they want to
@@ -308,19 +308,13 @@ When(/I tap the (button|link) "([^"]+)"/, async (elemType, phrase) => {
       [elem] = await scope.page.$x(`//button[contains(text(), "${phrase}")]`);
       if ( !elem ) {
         // This how we'll handle it for now, but oh boy
+        // Possibly look into https://stackoverflow.com/a/56044998/14144258
         [elem] = await scope.page.$x(`//div[contains(@class, "form-actions")]//a[contains(text(), "${phrase}")]`);
       }
     }
   } else {
     [elem] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
   }
-
-  // let elem;
-  // if (elemType === 'button') {
-  //   [elem] = await scope.page.$x(`//button/span[contains(text(), "${phrase}")]`);
-  // } else {
-  //   [elem] = await scope.page.$x(`//*[@class="form-actions"]//a[contains(text(), "${phrase}")]`);
-  // }
 
   let winner;
   if (elem) {

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -42,7 +42,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 
 const INTERVIEW_URL = interviewConstants.INTERVIEW_URL;
-setDefaultTimeout(20 * 1000);
+setDefaultTimeout(50 * 1000);
 
 let device_touch_map = {
   mobile: 'tap',
@@ -59,7 +59,7 @@ Given(/I start the interview[ on ]?(.*)/, async (optional_device) => {
 
   if (!scope.page) {
     scope.page = await scope.browser.newPage();
-    scope.page.setDefaultTimeout(20 * 1000)
+    scope.page.setDefaultTimeout(50 * 1000)
   }
 
   // Let developer pick mobile device if they want to
@@ -304,9 +304,23 @@ When(/I tap the (button|link) "([^"]+)"/, async (elemType, phrase) => {
   let elem;
   if (elemType === 'button') {
     [elem] = await scope.page.$x(`//button/span[contains(text(), "${phrase}")]`);
+    if ( !elem ) {
+      [elem] = await scope.page.$x(`//button[contains(text(), "${phrase}")]`);
+      if ( !elem ) {
+        // This how we'll handle it for now, but oh boy
+        [elem] = await scope.page.$x(`//div[contains(@class, "form-actions")]//a[contains(text(), "${phrase}")]`);
+      }
+    }
   } else {
     [elem] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
   }
+
+  // let elem;
+  // if (elemType === 'button') {
+  //   [elem] = await scope.page.$x(`//button/span[contains(text(), "${phrase}")]`);
+  // } else {
+  //   [elem] = await scope.page.$x(`//*[@class="form-actions"]//a[contains(text(), "${phrase}")]`);
+  // }
 
   let winner;
   if (elem) {
@@ -447,6 +461,19 @@ Then('I type {string} in the {string} field', async (value, field_label) => {
 Then('I type {string} in the unlabeled field', async (value) => {
   let text_field = await scope.page.type( `input[type="text"]`, value );
   await scope.afterStep(scope, {waitForShowIf: true});
+});
+
+Then('I sign', async () => {
+// Then('I sign', async () => {
+  let canvas = await scope.page.waitForSelector('canvas');
+  let bounding_box = await canvas.boundingBox();
+
+  await scope.page.mouse.move(bounding_box.x + bounding_box.width / 2, bounding_box.y + bounding_box.height / 2);
+  await scope.page.mouse.down();
+  // await scope.page.mouse.move(1, 1);
+  await scope.page.mouse.up();
+
+  await scope.afterStep(scope);
 });
 
 

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -401,8 +401,8 @@ When('I choose {string}', async (label_text) => {
 // TODO: Should we have a test just for the state of MA to be selected? Much easier... Or states in general
 // When('I select the {string} option from the {string} choices', async (option_text, label_text) => {
 When(/I select "([^"]+)" from the ?(?:"([^"]+)")? dropdown/, async (option_text, label_text) => {
-  /* Selects the option containing the text `option_text`
-  * in the <select> with the label "containing" the `label_text`.
+  /* Selects the option containing the text `option_text` in, if specified
+  *    the <select> with the label "containing" the `label_text`.
   *    Finding one dropdown out of a bunch is a future feature.
   * 
   * Note: `page.select()` is the only way to tap on an element in a <select>


### PR DESCRIPTION
Includes testing grammar for singular participant and singular landlord for shortest path. Kickout got both singular and plural tests.

As far as the test adjustments go, it turns out there's some funky stuff going on on the signature page (hidden buttons that don't do anything) and I had to fight back with some equally funky stuff. We'll just have to see how it all goes. I'm not sure `.form-actions` is going to cut it in the long run. [DA has its own way of dealing with it](https://github.com/jhpyle/docassemble/blob/master/tests/features/steps/docassemble.py#L160), but it doesn't help us deal with waiting for load or error.

It also implements signing.