### PR TITLE
Test multiple local signers/landlords, improve text field interaction such as...

### DIFF
--- a/tests/features/local_plurals.feature
+++ b/tests/features/local_plurals.feature
@@ -9,7 +9,7 @@ signing on their own devices.
 - [x] Two codefendants will sign on paper
 - [x] Codefendants each have all info and different info
 
-Scenario: Shortest successful path
+Scenario: Multiple local signers and landlords
   Given I start the interview
   When I tap the option with the text "I accept"
   When I tap the button "Next"

--- a/tests/features/local_plurals.feature
+++ b/tests/features/local_plurals.feature
@@ -130,14 +130,19 @@ Scenario: Multiple local signers and landlords
   Then I do nothing
   Then I tap the button "Next"
   Then I tap the button "This computer"
+  Then I should see the phrase "Ulli U. User Jr,"
   Then I sign
   When I tap the button "Next"
+  Then I should see the phrase "Sign C1 C. Codef Jr’s name"
   Then I sign
   When I tap the button "Next"
+  Then I should see the phrase "Sign C2 C. Codef II’s name"
   Then I sign
   When I tap the button "Next"
+  Then I should see the phrase "C3 C. Codef III,"
   Then I sign
   When I tap the button "Next"
+  Then I should see the phrase "C4 C. Codef IV,"
   Then I sign
   When I tap the button "Next"
   Then I should see the phrase "C1 C. Codef Jr, C2 C. Codef II, C3 C. Codef III, and C4 C. Codef IV have signed"

--- a/tests/features/local_plurals.feature
+++ b/tests/features/local_plurals.feature
@@ -2,12 +2,12 @@ Feature: Multiple codefendants and landlords signing in
 different ways with different info. Excludes codefendants
 signing on their own devices.
 
-- [ ] Multiple codefendants
-- [ ] Multiple landlords
-- [ ] Two codefendants sign on user's device
-- [ ] User signs for two codefendants
-- [ ] Two codefendants will sign on paper
-- [ ] Codefendants each have all info and different info
+- [x] Multiple codefendants
+- [x] Multiple landlords
+- [x] Two codefendants sign on user's device
+- [x] User signs for two codefendants
+- [x] Two codefendants will sign on paper
+- [x] Codefendants each have all info and different info
 
 Scenario: Shortest successful path
   Given I start the interview

--- a/tests/features/local_plurals.feature
+++ b/tests/features/local_plurals.feature
@@ -1,0 +1,145 @@
+Feature: Multiple codefendants and landlords signing in
+different ways with different info. Excludes codefendants
+signing on their own devices.
+
+- [ ] Multiple codefendants
+- [ ] Multiple landlords
+- [ ] Two codefendants sign on user's device
+- [ ] User signs for two codefendants
+- [ ] Two codefendants will sign on paper
+- [ ] Codefendants each have all info and different info
+
+Scenario: Shortest successful path
+  Given I start the interview
+  When I tap the option with the text "I accept"
+  When I tap the button "Next"
+  Then I do nothing
+  Then I tap the button "Next"
+  Then I type "Ulli" in the "First Name" field
+  Then I type "Umiddle" in the "Middle Name" field
+  Then I type "User" in the "Last Name" field
+  Then I select "Jr" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I tap the option with the text "wants to file with me"
+  Then I tap the button "Next"
+
+  Then I type "C1" in the "First Name" field
+  Then I type "Coda" in the "Middle Name" field
+  Then I type "Codef" in the "Last Name" field
+  Then I select "Jr" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I type "111-111-1111" in the "Mobile number" field
+  Then I type "111-111-2222" in the "Other phone number" field
+  Then I type "c1@example.com" in the "Email address" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "sign their name for them"
+  Then I tap the button "Next"
+  Then I tap the button "Yes"
+
+  Then I type "C2" in the "First Name" field
+  Then I type "Coda" in the "Middle Name" field
+  Then I type "Codef" in the "Last Name" field
+  Then I select "II" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I type "222-222-1111" in the "Mobile number" field
+  Then I type "222-222-2222" in the "Other phone number" field
+  Then I type "c2@example.com" in the "Email address" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "sign their name for them"
+  Then I tap the button "Next"
+  Then I tap the button "Yes"
+
+  Then I type "C3" in the "First Name" field
+  Then I type "Coda" in the "Middle Name" field
+  Then I type "Codef" in the "Last Name" field
+  Then I select "III" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I type "333-333-1111" in the "Mobile number" field
+  Then I type "333-333-2222" in the "Other phone number" field
+  Then I type "c3@example.com" in the "Email address" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "sign with me"
+  Then I tap the button "Next"
+  Then I tap the button "Yes"
+
+  Then I type "C4" in the "First Name" field
+  Then I type "Coda" in the "Middle Name" field
+  Then I type "Codef" in the "Last Name" field
+  Then I select "IV" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I type "444-444-1111" in the "Mobile number" field
+  Then I type "444-444-2222" in the "Other phone number" field
+  Then I type "c4@example.com" in the "Email address" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "sign with me"
+  Then I tap the button "Next"
+  Then I tap the button "Yes"
+
+  Then I type "C5" in the "First Name" field
+  Then I type "Coda" in the "Middle Name" field
+  Then I type "Codef" in the "Last Name" field
+  Then I select "V" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I type "555-555-1111" in the "Mobile number" field
+  Then I type "555-555-2222" in the "Other phone number" field
+  Then I type "c5@example.com" in the "Email address" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "paper"
+  Then I tap the button "Next"
+  Then I tap the button "Yes"
+
+  Then I type "C6" in the "First Name" field
+  Then I type "Coda" in the "Middle Name" field
+  Then I type "Codef" in the "Last Name" field
+  Then I select "VI" from the "Suffix" dropdown
+  Then I tap the button "Next"
+  Then I type "666-666-1111" in the "Mobile number" field
+  Then I type "666-666-2222" in the "Other phone number" field
+  Then I type "c6@example.com" in the "Email address" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "paper"
+  Then I tap the button "Next"
+  Then I tap the button "No"
+
+  Then I tap the option with the text "we are not risking"
+  Then I tap the button "Next"
+  Then I type "112 Southampton St" in the "Street address" field
+  Then I type "1" in the "Unit" field
+  Then I type "Boston" in the "City" field
+  Then I select "Massachusetts" from the "State" dropdown
+  Then I type "02118" in the "Zip" field
+  Then I tap the button "Next"
+  Then I type "201 555-1111" in the "Mobile number" field
+  Then I type "202 555-2222" in the "Other phone number" field
+  Then I type "user@example.com" in the "Email address" field
+  Then I type "Semaphore" in the "Other ways to reach you" field
+  Then I tap the button "Next"
+
+  Then I type "2" in the unlabeled field
+  Then I tap the button "Next"
+  Then I type "Landlord 1" in the unlabeled field
+  Then I tap the button "Next"
+  Then I type "Landlord 2" in the unlabeled field
+  Then I tap the button "Next"
+  Then I select "Attleboro District Court" from the dropdown
+  Then I tap the button "Next"
+  Then I type "111" in the "Docket number" field
+  Then I tap the button "Next"
+  Then I tap the option with the text "No"
+  Then I tap the button "Next"
+  Then I do nothing
+  Then I tap the button "Next"
+  Then I tap the button "This computer"
+  Then I sign
+  When I tap the button "Next"
+  Then I sign
+  When I tap the button "Next"
+  Then I sign
+  When I tap the button "Next"
+  Then I sign
+  When I tap the button "Next"
+  Then I sign
+  When I tap the button "Next"
+  Then I should see the phrase "C1 C. Codef Jr, C2 C. Codef II, C3 C. Codef III, and C4 C. Codef IV have signed"
+  Then I should see the phrase "C5 C. Codef IV will sign"
+  Then I should see the phrase "C6 C. Codef VI will sign"

--- a/tests/features/shortest_path.feature
+++ b/tests/features/shortest_path.feature
@@ -4,6 +4,8 @@ Feature: Shortest successful path with all possible information
 - [x] Give most info possible
 - [ ] Check for singulars
 
+Think this is missing some kind of singluar check for the landlord
+
 Scenario: Shortest successful path
   Given I start the interview
   When I tap the option with the text "I accept"
@@ -24,8 +26,8 @@ Scenario: Shortest successful path
   Then I select "Massachusetts" from the "State" dropdown
   Then I type "02118" in the "Zip" field
   Then I tap the button "Next"
-  Then I type "201 555-0123" in the "Mobile number" field
-  Then I type "202 555-0123" in the "Other phone number" field
+  Then I type "101 555-1111" in the "Mobile number" field
+  Then I type "102 555-2222" in the "Other phone number" field
   Then I type "user@example.com" in the "Email address" field
   Then I type "Semaphore" in the "Other ways to reach you" field
   Then I tap the button "Next"

--- a/tests/features/support/scope.js
+++ b/tests/features/support/scope.js
@@ -1,11 +1,11 @@
 module.exports = {
   getTextFieldId: async function getTextFieldId(scope, field_label) {
+    /* Get the ID of the text field with the name containing `label_name` */
     // make sure at least one is on screen
-    await scope.page.waitFor('label[class*="datext"]');
+    await scope.page.waitFor('#daquestion .da-form-label');
 
-    let field_id = await scope.page.$$eval('label[class*="datext"]', (elements, field_label) => {
-      let elems_array = Array.from( elements );
-      for ( let elem of elems_array ) {
+    let field_id = await scope.page.$$eval('#daquestion .da-form-label', (elements, field_label) => {
+      for ( let elem of elements ) {
         if (( elem.innerText ).includes( field_label )) {
           return elem.getAttribute( 'for' );
         }

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -447,15 +447,21 @@ When(/I select "([^"]+)" from the ?(?:"([^"]+)")? dropdown/, async (option_text,
 //   }
 // );
 
+// TODO: combine the two typing steps by using regex? It would allow a simple 'I type ""'
 Then('I type {string} in the {string} field', async (value, field_label) => {
+  /* Clears the matching textfield in the question area and then types in it */
   let id = await scope.getTextFieldId(scope, field_label);
-  await scope.page.type( '#' + id, value );
-
+  await scope.page.$eval(`#${id}`, (el) => { el.value = ''});
+  await scope.page.type( `#${id}`, value );
   await scope.afterStep(scope, {waitForShowIf: true});
 });
 
+// Alternatively, we could put this text in every input field on the page. That would be interesting.
+// I type "" in all the fields
 Then('I type {string} in the unlabeled field', async (value) => {
-  let text_field = await scope.page.type( `input[type="text"]`, value );
+  /* Clears the first textfield in the question area and then types in it */
+  await scope.page.$eval(`#daquestion input[alt*="Input box"]`, (el) => { el.value = ''});
+  await scope.page.type( `#daquestion input[alt*="Input box"]`, value );
   await scope.afterStep(scope, {waitForShowIf: true});
 });
 


### PR DESCRIPTION
1. Clears text field before typing in it
1. Uses effective selectors to get the _right_ text field

[Note: The checkboxes for the tests are focused on features, not scenarios. We should chat about that]

Thinking about combining the 2 text field operations into 1 to eventually allow a sentence like `I type "a thing"` and `I type a thing in the first field`.

Also thinking about how to standardize input text a bit between repositories. May change 'Landlord 1' etc. to 'Other Party 1' or something.